### PR TITLE
discovery.xml: Fix DSpace 5-ism in search filter

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -654,8 +654,7 @@
             </list>
         </property>
         <property name="facetLimit" value="5"/>
-        <property name="sortOrderSidebar" value="COUNT"/>
-        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="sortOrder" value="COUNT"/>
     </bean>
 
     <bean id="searchFilterAffiliation" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">


### PR DESCRIPTION
I had copied this filter from DSpace 5, my bad.
