### PR TITLE
Add new Google Analytics Tracking ID for CIP

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/CIP/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/CIP/lib/xsl/core/page-structure.xsl
@@ -699,7 +699,7 @@
 
 		<script type="text/javascript">
 			var _gaq = _gaq || [];
-			_gaq.push(['_setAccount','UA-51611288-1']);
+			_gaq.push(['_setAccount','UA-69666701-1']);
 			_gaq.push(['_trackPageview']);
 
 			(function() {


### PR DESCRIPTION
In #142 we noticed that some communities were using incorrect tracking IDs.
