### PR TITLE
Changes to social sharing icons

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
@@ -12,7 +12,7 @@
     "html5shiv": "3.7.2",
     "holderjs": "2.4.1",
     "chartist" :"0.9.4",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0",
     "datatables": "1.10.3"
   },

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
@@ -13,6 +13,7 @@
     "holderjs": "2.4.1",
     "chartist" :"0.9.4",
     "fontawesome": "4.2.0",
+    "academicons": "1.6.0",
     "datatables": "1.10.3"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -1,6 +1,7 @@
 $fa-font-path: "../vendor/fontawesome/fonts";
 
 @import "../vendor/fontawesome/scss/font-awesome";
+@import "../vendor/academicons/css/academicons.css";
 @import "atmire-cua";
 @import "atmire-cua-customizations";
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -227,7 +227,7 @@ div.secondary.search-browse{
   margin-bottom: 8px;
 }
 
-.item-summary-view-metadata .fa {
+.item-summary-view-metadata .fa, .item-summary-view-metadata .ai {
   color: #333;
   margin: 2px;
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -228,6 +228,6 @@ div.secondary.search-browse{
 }
 
 .item-summary-view-metadata .fa, .item-summary-view-metadata .ai {
-  color: #333;
+  color: $brand-primary;
   margin: 2px;
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -622,6 +622,12 @@ such as authors, subject, citation, description, etc
                 <span class="fa fa-linkedin-square fa-lg"></span>
             </a>
             <a>
+                <xsl:attribute name="href"><xsl:text>https://delicious.com/save?v=5&amp;provider=CGSpace&amp;noui&amp;jump=close&amp;url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
+                <xsl:attribute name="title"><xsl:text>Save this on Delicious</xsl:text></xsl:attribute>
+                <xsl:attribute name="target"><xsl:text>_blank</xsl:text></xsl:attribute>
+                <span class="fa fa-delicious fa-lg"></span>
+            </a>
+            <a>
                 <xsl:attribute name="href"><xsl:text>https://www.mendeley.com/import/?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Add this article to your Mendeley library</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -618,6 +618,11 @@ such as authors, subject, citation, description, etc
                 <span class="fa fa-linkedin-square fa-lg"></span>
             </a>
             <a>
+                <xsl:attribute name="href"><xsl:text>https://www.mendeley.com/import/?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
+                <xsl:attribute name="title"><xsl:text>Add this article to your Mendeley library</xsl:text></xsl:attribute>
+                <span class="ai ai-mendeley-square ai-lg"></span>
+            </a>
+            <a>
                 <xsl:attribute name="href"><xsl:text>mailto:?&amp;body=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/><xsl:text>&amp;media=&amp;description=</xsl:text></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share via e-mail</xsl:text></xsl:attribute>
                 <span class="fa fa-envelope fa-lg"></span>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -600,26 +600,31 @@ such as authors, subject, citation, description, etc
             <a>
                 <xsl:attribute name="href"><xsl:text>https://twitter.com/home?status=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Tweet this</xsl:text></xsl:attribute>
+                <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
                 <span class="fa fa-twitter-square fa-lg"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://www.facebook.com/sharer/sharer.php?u=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share on Facebook</xsl:text></xsl:attribute>
+                <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
                 <span class="fa fa-facebook-square fa-lg"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://plus.google.com/share?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share on Google+</xsl:text></xsl:attribute>
+                <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
                 <span class="fa fa-google-plus-square fa-lg"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://www.linkedin.com/shareArticle?mini=true&amp;url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share on LinkedIn</xsl:text></xsl:attribute>
+                <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
                 <span class="fa fa-linkedin-square fa-lg"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://www.mendeley.com/import/?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Add this article to your Mendeley library</xsl:text></xsl:attribute>
+                <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
                 <span class="ai ai-mendeley-square ai-lg"></span>
             </a>
             <a>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0",
+    "fontawesome": "4.5.0",
     "academicons": "1.6.0"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
-    "fontawesome": "4.2.0"
+    "fontawesome": "4.2.0",
+    "academicons": "1.6.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Add Delicious and Mendeley icons, update Font Awesome for new G+ branding, change icon color to Bootstrap `$brand-primary`, and make links open in new windows.

Closes #157 #159.
