### PR TITLE
discovery.xml: Increase all date-based facets to 10

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -465,7 +465,7 @@
                 <value>dc.date.issued</value>
             </list>
         </property>
-        <property name="facetLimit" value="5"/>
+        <property name="facetLimit" value="10"/>
         <property name="type" value="date"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
@@ -490,7 +490,7 @@
                 <value>dc.date.accessioned</value>
             </list>
         </property>
-        <property name="facetLimit" value="5"/>
+        <property name="facetLimit" value="10"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>


### PR DESCRIPTION
Date-based facets are designed to be drilled down, so they need to be able to show at least 10 values in a range, ie 2000–2010.
