### PR TITLE
dspace.cfg: Set Atom/RSS feed cache to 3 hours

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1471,7 +1471,7 @@ webui.feed.items = 8
 webui.feed.cache.size = 100
 # number of hours to keep cached feeds before checking currency
 # value of 0 will force a check with each request
-webui.feed.cache.age = 48
+webui.feed.cache.age = 3
 # which syndication formats to offer
 # use one or more (comma-separated) values from list:
 # rss_0.90, rss_0.91, rss_0.92, rss_0.93, rss_0.94, rss_1.0, rss_2.0


### PR DESCRIPTION
The default is 48 hours, which is ridiculous for any repository that publishes new items several times per day.

Closes #170.
