### PR TITLE
XMLUI: Fix for long URLs in item view

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -231,3 +231,9 @@ div.secondary.search-browse{
   color: $brand-primary;
   margin: 2px;
 }
+
+// fix for long URLs in item view
+// https://github.com/ilri/DSpace/issues/172
+.simple-item-view-description .marginleft {
+  text-align: left;
+}


### PR DESCRIPTION
When items have long URLs on the item view they wrap and create a lot of awkward space because the parent div is forced the content to be justified.

Closes #172.
