### PR TITLE
xmlui: Tweak buttons in submission step to use brand colors

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -237,3 +237,19 @@ div.secondary.search-browse{
 .simple-item-view-description .marginleft {
   text-align: left;
 }
+
+// buttons on submit page should have brand colors
+.btn-success {
+  background-color: $brand-primary;
+  border-color: darken($brand-primary, 5%);
+}
+
+.btn-success:hover, .btn-success:focus, .btn-success:active {
+  background-color: lighten($brand-primary, 5%);
+  border-color: $brand-primary;
+}
+
+.btn-success[disabled] {
+  background-color: lighten($brand-primary, 10%);
+  border-color: lighten($brand-primary, 5%);
+}


### PR DESCRIPTION
Just piggyback on `$brand-primary` and use some relative colors with SASS' darken/lighten functions for borders, active, and disabled states. Looks much better than the defaults:

<img width="529" alt="screen shot 2016-02-08 at 12 49 34" src="https://cloud.githubusercontent.com/assets/191754/12884251/acbe38fa-ce65-11e5-9fe0-2b29e2b60685.png">
<img width="547" alt="screen shot 2016-02-08 at 13 07 40" src="https://cloud.githubusercontent.com/assets/191754/12884252/acc201ce-ce65-11e5-85d6-31f5af1ac98f.png">

Fixes #154.
