### PR TITLE
[DS-2679] Retain ordering of authors for Google Scholar metatags.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -28,6 +28,7 @@ import org.dspace.core.ConfigurationManager;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
@@ -757,16 +758,17 @@ public class GoogleMetadata
     }
 
     /**
-     * Fetch all metadata mappings
-     * 
+     * Fetch retaining the order of the values for any given key in which they
+     * where added (like authors).
+     *
      * Usage: GoogleMetadata gmd = new GoogleMetadata(item); for(Entry<String,
      * String> mapping : googlemd.getMappings()) { ... }
      * 
      * @return Iterable of metadata fields mapped to Google-formatted values
      */
-    public Set<Entry<String, String>> getMappings()
+    public Collection<Entry<String, String>> getMappings()
     {
-        return new HashSet<>(metadataMappings.entries());
+        return metadataMappings.entries();
     }
 
     /**


### PR DESCRIPTION
Fixed in DSpace 5.4 and 6.0, see: https://jira.duraspace.org/browse/DS-2679
