### PR TITLE
Fixes for dc.type

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -108,7 +108,7 @@
     <message key="xmlui.Discovery.AbstractSearch.type_bioversity">Filter by: Biodiversity subjects</message>
     <message key="xmlui.Discovery.AbstractSearch.type_country">Filter by: Country</message>
     <message key="xmlui.Discovery.AbstractSearch.type_region">Filter by: Region</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_outputtype">Filter by: Outputtype</message>
+    <message key="xmlui.Discovery.AbstractSearch.type_type">Filter by: Output type</message>
     <message key="xmlui.Discovery.AbstractSearch.type_affiliation">Filter by: Author Affiliation</message>
 
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Author</message>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -330,7 +330,7 @@ search.index.19 = iwmisubject:dc.iwsubject.iwmisubject
 search.index.20 = subregion:dc.srplace.subregion
 search.index.21 = crpsubject:dc.crsubject.crpsubject
 search.index.22 = basin:dc.river.basin
-search.index.23 = output:dc.type.output
+search.index.23 = output:dc.type.*
 search.index.24 = issuedate:dc.date.issued
 search.index.25 = accessioneddate:dc.date.accessioned:timestamp
 search.index.26 = cta:cg.subject.cta
@@ -1228,7 +1228,7 @@ webui.browse.index.24 = breed:metadata:cg.species.breed:text
 webui.itemlist.sort-option.1 = title:dc.title:title
 webui.itemlist.sort-option.2 = dateissued:dc.date.issued:date
 webui.itemlist.sort-option.3 = dateaccessioned:dc.date.accessioned:date
-webui.itemlist.sort-option.4 = type:dc.type.output:text
+webui.itemlist.sort-option.4 = type:dc.type.*:text
 
 # By default, the display of metadata in the browse indexes is case sensitive
 # So, you will get separate entries for the terms

--- a/dspace/config/modules/atmire-cua.cfg
+++ b/dspace/config/modules/atmire-cua.cfg
@@ -104,15 +104,14 @@ content.analysis.dataset.option.18=metadata:country:discovery
 content.analysis.dataset.option.19=metadata:subregion:discovery
 content.analysis.dataset.option.20=metadata:crpsubject:discovery
 content.analysis.dataset.option.21=metadata:basin:discovery
-content.analysis.dataset.option.22=metadata:output:discovery
-content.analysis.dataset.option.23=metadata:cta:discovery
-content.analysis.dataset.option.24=metadata:wlesubject:discovery
-content.analysis.dataset.option.25=metadata:bioversity:discovery
-content.analysis.dataset.option.26=metadata:ciat:discovery
-content.analysis.dataset.option.27=metadata:humidtropics:discovery
-content.analysis.dataset.option.28=metadata:cipsubject:discovery
-content.analysis.dataset.option.29=metadata:drylandssubject:discovery
-content.analysis.dataset.option.30=metadata:icardasubject:discovery
+content.analysis.dataset.option.22=metadata:cta:discovery
+content.analysis.dataset.option.23=metadata:wlesubject:discovery
+content.analysis.dataset.option.24=metadata:bioversity:discovery
+content.analysis.dataset.option.25=metadata:ciat:discovery
+content.analysis.dataset.option.26=metadata:humidtropics:discovery
+content.analysis.dataset.option.27=metadata:cipsubject:discovery
+content.analysis.dataset.option.28=metadata:drylandssubject:discovery
+content.analysis.dataset.option.29=metadata:icardasubject:discovery
 
 
 #Indicating how many different values may be found for a metadata option before an autocomplete text field i used

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -878,17 +878,6 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="VALUE"/>
     </bean>
-    <bean id="searchFilterType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
-        <property name="indexFieldName" value="type"/>
-        <property name="metadataFields">
-            <list>
-                <value>dc.type</value>
-            </list>
-        </property>
-        <property name="facetLimit" value="10"/>
-        <property name="sortOrderSidebar" value="COUNT"/>
-        <property name="sortOrderFilterPage" value="VALUE"/>
-    </bean>
     <bean class="com.atmire.dspace.discovery.AtmireSolrService" id="org.dspace.discovery.SearchService"/>
     <bean class="com.atmire.dspace.discovery.HasBitstreamsSSIPlugin" id="hasBitstreamsSSIPlugin"/>
     <bean class="com.atmire.dspace.discovery.ItemCollectionPlugin" id="itemCollectionPlugin"/>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -99,7 +99,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutput" />
+                <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />
@@ -129,7 +129,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutput" />
+                <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />
@@ -233,7 +233,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutput" />
+                <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />
@@ -264,7 +264,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutput" />
+                <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />
@@ -639,8 +639,8 @@
         <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
 
-    <bean id="searchFilterOutput" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
-        <property name="indexFieldName" value="output"/>
+    <bean id="searchFilterType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="type"/>
         <property name="metadataFields">
             <list>
                 <value>dc.type.*</value>
@@ -771,18 +771,6 @@
         <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
 
-    <bean id="searchFilterOutputType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
-        <property name="indexFieldName" value="outputtype"/>
-        <property name="metadataFields">
-            <list>
-                <value>dc.type.output</value>
-            </list>
-        </property>
-        <property name="facetLimit" value="10"/>
-        <property name="sortOrderSidebar" value="COUNT"/>
-        <property name="sortOrderFilterPage" value="VALUE"/>
-    </bean>
-
     <bean id="searchFilterBreed" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="breed"/>
         <property name="metadataFields">
@@ -839,7 +827,6 @@
                 <ref bean="searchFilterSubregion"/>
                 <ref bean="searchFilterCrpsubject"/>
                 <ref bean="searchFilterBasin"/>
-                <ref bean="searchFilterOutput"/>
                 <ref bean="searchFilterCta"/>
                 <ref bean="searchFilterWlesubject"/>
                 <ref bean="searchFilterBioversity"/>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -99,7 +99,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutputType" />
+                <ref bean="searchFilterOutput" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />
@@ -129,7 +129,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutputType" />
+                <ref bean="searchFilterOutput" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />
@@ -233,7 +233,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutputType" />
+                <ref bean="searchFilterOutput" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />
@@ -264,7 +264,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterOutputType" />
+                <ref bean="searchFilterOutput" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterRegion" />
                 <ref bean="searchFilterCountry" />

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -805,6 +805,12 @@
             </list>
         </property>
         <!--The search filters which can be used on the discovery search page-->
+
+        <!-- Note from Alan: indexes for search filters are only created if you
+             actually use them in a searchFilters property. Simply defining a
+             filter doesn't create the index! Atmire's strategy is to list the
+             filters here just in case we aren't using them in the site-wide
+             sidebarFacets configuration -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle"/>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -598,7 +598,7 @@ such as authors, subject, citation, description, etc
                 <xsl:for-each select="dim:field[@element='type' and @qualifier='output' ]">
                     <a target="_black" >
                         <xsl:attribute name="href">
-                            <xsl:value-of select="concat($context-path,'/discover?filtertype=outputtype&amp;filter_relational_operator=equals&amp;filter=',url:encode(node()))"></xsl:value-of>
+                            <xsl:value-of select="concat($context-path,'/discover?filtertype=type&amp;filter_relational_operator=equals&amp;filter=',url:encode(node()))"></xsl:value-of>
                         </xsl:attribute>
                         <xsl:copy-of select="./node()"/>
                     </a>                    <xsl:if test="count(following-sibling::dim:field[@element='type' and @qualifier='output'] ) != 0">

--- a/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
@@ -956,7 +956,7 @@ DAMAGE.
     <message key="xmlui.metadataquality.batch-edit.field.label.dc.title.alternative">Alternative Title (dc.title.alternative)</message>
     <message key="xmlui.metadataquality.batch-edit.field.label.dc.title">Title (dc.title)</message>
     <message key="xmlui.metadataquality.batch-edit.field.label.dc.type.template">Type Template (dc.type.template)</message>
-    <message key="xmlui.metadataquality.batch-edit.field.label.dc.type">Type (dc.type)</message>
+    <message key="xmlui.metadataquality.batch-edit.field.label.dc.type">Type (dc.type.*)</message>
     <message key="xmlui.metadataquality.batch-edit.field.label.workflow.batchedit.claimedby">Batch edit step claimed user identifier (workflow.batchedit.claimedby)</message>
 
 

--- a/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
@@ -584,7 +584,7 @@ DAMAGE.
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.dc.title">Title (dc.title)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.dc.type.template">Type Template (dc.type.template)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.dc.type">Type (dc.type)</message>
-    <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.type">Type (dc.type)</message>
+    <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.type">Type (dc.type.*)</message>
 
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.type">Submit Date (dc.date.accessioned)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.status">Status (dc.identifier.status)</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
@@ -600,7 +600,6 @@ DAMAGE.
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.subregion">Sub region (dc.srplace.*)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.crpsubject">CGIAR Research Program (dc.crsubject.*)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.basin">River Basin (dc.river.*)</message>
-    <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.output">Output (dc.type)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.cta">CTA Subject (cg.subject.cta)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.wlesubject">WLE Subject (cg.subject.wle)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.bioversity">Bioversity Subject (cg.subject.bioversity)</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -103,7 +103,7 @@
    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">issue date</message>
    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">submit date</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">relevance</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.output">output type</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.type">output type</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Sort items by</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">in order</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascending</message>
@@ -415,7 +415,7 @@
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.drylandssubject">Dryland Systems subject</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.icardasubject">ICARDA subject</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.affiliation">Author affiliation</message>
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.outputtype">Output type</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.type">Type</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.bioversity">Bioversity subject</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.ccafsubject">CCAFS subject</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.ciat">CIAT subject</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -140,7 +140,7 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subregion">Sub regions</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_crpsubject">CGIAR Research Programs</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_basin">River basins</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_output">Output types</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type">Output types</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_cta">CTA subjects</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_wlesubject">WLE subjects</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_bioversity">Bioversity subjects</message>
@@ -150,7 +150,6 @@
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_drylandssubject">Dryland Systems subjects</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_icardasubject">ICARDA subjects</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_iitasubject">IITA subjects</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_outputtype">Output types</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_affiliation">Author affiliations</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_status">Status</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_breed">Animal breed</message>


### PR DESCRIPTION
We had been confusing `dc.type` and `dc.type.output` for a few years—the former is a vanilla Dublin Core field, while the latter is one we invented. This affected many of our indexes, XMLUI item displays, etc. This is part of the work that needed to be done for #132. We still need to clean up some old strings for "Browse by", as well as fix all the metadata values themselves... but later.

Requires a full Discovery re-index (-b).
