### PR TITLE
dspace.cfg: Revert search.index.* to default state

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -320,27 +320,6 @@ search.index.9 = mime:dc.format.mimetype
 search.index.10 = sponsor:dc.description.sponsorship
 search.index.11 = identifier:dc.identifier.*
 search.index.12 = language:dc.language.iso
-search.index.13 = ilrisubject:dc.isubject.ilrisubject
-search.index.14 = cpwfsubject:dc.cpsubject.cpwfsubject
-search.index.15 = country:dc.cplace.country
-search.index.16 = region:dc.rplace.region
-search.index.17 = ccafsubject:dc.ccsubject.ccafsubject
-search.index.18 = ciforsubject:dc.cisubject.ciforsubject
-search.index.19 = iwmisubject:dc.iwsubject.iwmisubject
-search.index.20 = subregion:dc.srplace.subregion
-search.index.21 = crpsubject:dc.crsubject.crpsubject
-search.index.22 = basin:dc.river.basin
-search.index.23 = output:dc.type.*
-search.index.24 = issuedate:dc.date.issued
-search.index.25 = accessioneddate:dc.date.accessioned:timestamp
-search.index.26 = cta:cg.subject.cta
-search.index.27 = wlesubject:cg.subject.wle
-search.index.28 = bioversity:cg.subject.bioversity
-search.index.29 = common_status_identifier:dc.identifier.status
-search.index.30 = jtitle:dc.title.jtitle
-search.index.31 = ISI_Journal:dc.isijournal
-search.index.32 = ciat:cg.subject.ciat
-search.index.33 = humidtropics:cg.subject.humidtropics
 
 ##### Handle settings ######
 


### PR DESCRIPTION
These are only used by Lucene indexing, which has been deprecated in favor of Discovery search since DSpace 5.x. Search indexes are now defined in discovery.xml.
