### PR TITLE
input-forms.xml: Change input for "Type" to dc.type

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -129,7 +129,7 @@
         <field>
           <dc-schema>dc</dc-schema>
           <dc-element>type</dc-element>
-          <dc-qualifier>output</dc-qualifier>
+          <dc-qualifier></dc-qualifier>
           <repeatable>true</repeatable>
           <label>Item type (required)</label>
           <input-type value-pairs-name="common_types">dropdown</input-type>


### PR DESCRIPTION
We are trying to move away from using dc.type.output to specify the item's type, in favor of Dublin Core's dc.type. Part of #132.
