### PR TITLE
Tweaks for robots.txt

### DIFF
--- a/dspace-xmlui/src/main/webapp/static/robots.txt
+++ b/dspace-xmlui/src/main/webapp/static/robots.txt
@@ -22,15 +22,15 @@ Disallow: /handle/${handle.prefix}/*/browse
 #
 # If you have configured DSpace (Solr-based) Statistics to be publicly 
 # accessible, then you may not want this content to be indexed
-# Disallow: /statistics
+Disallow: /statistics
 #
 # You also may wish to disallow access to the following paths, in order
 # to stop web spiders from accessing user-based content
-# Disallow: /contact
-# Disallow: /feedback
-# Disallow: /forgot
-# Disallow: /login
-# Disallow: /register
+Disallow: /contact
+Disallow: /feedback
+Disallow: /forgot
+Disallow: /login
+Disallow: /register
 
 
 ##############################

--- a/dspace-xmlui/src/main/webapp/static/robots.txt
+++ b/dspace-xmlui/src/main/webapp/static/robots.txt
@@ -17,8 +17,8 @@ Disallow: /handle/${handle.prefix}/*/search-filter
 #
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.
-# Disallow: /browse
-# Disallow: /handle/${handle.prefix}/*/browse
+Disallow: /browse
+Disallow: /handle/${handle.prefix}/*/browse
 #
 # If you have configured DSpace (Solr-based) Statistics to be publicly 
 # accessible, then you may not want this content to be indexed

--- a/dspace-xmlui/src/main/webapp/static/robots.txt
+++ b/dspace-xmlui/src/main/webapp/static/robots.txt
@@ -11,11 +11,14 @@ Sitemap: ${dspace.url}/htmlmap
 User-agent: *
 # Disable access to Discovery search and filters
 Disallow: /discover
+Disallow: /handle/${handle.prefix}/*/discover
 Disallow: /search-filter
+Disallow: /handle/${handle.prefix}/*/search-filter
 #
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.
 # Disallow: /browse
+# Disallow: /handle/${handle.prefix}/*/browse
 #
 # If you have configured DSpace (Solr-based) Statistics to be publicly 
 # accessible, then you may not want this content to be indexed


### PR DESCRIPTION
This fixes the over-indexing problem discovered in #198 and optimizes bot usage by forcing them to consume the sitemap instead of crawling.
