### PR TITLE
Update Atmire Listings and Reports for Output→Type change

### DIFF
--- a/dspace/config/modules/atmire-listings-and-reports.cfg
+++ b/dspace/config/modules/atmire-listings-and-reports.cfg
@@ -25,7 +25,7 @@ plugin.single.org.infoCon.ConverterPlugin = org.infoCon.StringInfoconConverterPl
 
 ##### Filter types for the bibliography generator #####
 # format: biblio.filtertype.[number] = id, type, propertyKey (for the label. If <propertyKey>.hint exists. It will be shown as a help text above the filter's settings), schema.element.qualifier (if the qualifier is null don't put the ".qualifier"), boolean useAsGroupType (optional. default = true, input filtertypes can't be used as groups), discovery field name
-biblio.filtertype.1 = common_types, valuepairs, jsp.export.filter-categories.type, dc.type.output, true, dc.type.output
+biblio.filtertype.1 = common_types, valuepairs, jsp.export.filter-categories.type, dc.type, true, type
 biblio.filtertype.2 = sponsor, input, jsp.export.filter-categories.sponsor, dc.description.sponsorship, false, dc.description.sponsorship
 biblio.filtertype.3 = countrylist, valuepairs, jsp.export.filter-categories.country, dc.cplace.country, true, dc.cplace.country
 biblio.filtertype.4 = region_types, valuepairs, jsp.export.filter-categories.region, dc.rplace.region, true, dc.rplace.region


### PR DESCRIPTION
This was forgotten during the move last week and broke the Listings and Reports module. I'm not sure why we don't use `dc.type.*` for the schema and something other than `type` for the Discovery field, but I will have to ask Atmire people about it because the docs are not very specific, and this works.
