### PR TITLE
input-forms.xml: Fix one more rogue dc.type.output

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -742,9 +742,9 @@
         <field>
           <dc-schema>dc</dc-schema>
           <dc-element>type</dc-element>
-          <dc-qualifier>output</dc-qualifier>
+          <dc-qualifier></dc-qualifier>
           <repeatable>true</repeatable>
-          <label>Type</label>
+          <label>Item type (required)</label>
           <input-type value-pairs-name="common_types">dropdown</input-type>
           <hint>Select the type(s) of content of the item. To select more than one value in the list, you may have to hold down the "Ctrl" or "Shift" key.</hint>
           <required></required>


### PR DESCRIPTION
Last month we did a major cleanup of `dc.type.output` (#132 #187 #194) and it looks like I missed one in the input forms.
