### PR TITLE
Fix reference to dc.type.output in Discovery display

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
@@ -161,8 +161,8 @@
 
                             </div>
                         </xsl:if>
-                        <xsl:if test="dri:list[@n=(concat($handle, ':dc.type.output'))]">
-                            <xsl:variable name="type" select="dri:list[@n=(concat($handle, ':dc.type.output'))]/dri:item"/>
+                        <xsl:if test="dri:list[@n=(concat($handle, ':dc.type'))]">
+                            <xsl:variable name="type" select="dri:list[@n=(concat($handle, ':dc.type'))]/dri:item"/>
                             <div class="artifact-type">
                                 <span class="descriptionlabel">Type :</span>
                                 <xsl:value-of select="$type"/>


### PR DESCRIPTION
This is one reference I missed when we did the dc.type.output to dc.type migration a few weeks ago.
