### PR TITLE
A few small fixes for XMLUI

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-list-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-list-alterations.xsl
@@ -72,7 +72,7 @@
 
             </div>
             <div>
-                <span class="descriptionlabel">Authors :</span>
+                <span class="descriptionlabel">Authors:</span>
                 <span class="description-info">
                     <xsl:choose>
                         <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
@@ -125,7 +125,7 @@
             <div>
                 <xsl:if test="dim:field[@element='date' and @qualifier='issued']">
                     <div>
-                        <span class="descriptionlabel">Date :</span>
+                        <span class="descriptionlabel">Date:</span>
 
                         <span class="date">
                             <xsl:value-of
@@ -137,7 +137,7 @@
                 <xsl:if test="dim:field[@element = 'type']">
                     <xsl:variable name="type" select="dim:field[@element = 'type']/node()"/>
                     <div class="artifact-type">
-                        <span class="descriptionlabel">Type :</span>
+                        <span class="descriptionlabel">Type:</span>
                         <xsl:value-of select="$type"/>
                     </div>
                 </xsl:if>
@@ -145,7 +145,7 @@
                     <xsl:variable name="status"
                                   select="dim:field[@element = 'identifier' and @qualifier='status']/node()"/>
                     <div class="artifact-type">
-                        <span class="descriptionlabel">Status :</span>
+                        <span class="descriptionlabel">Status:</span>
                         <xsl:value-of select="$status"/>
                     </div>
                 </xsl:if>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -538,7 +538,7 @@ such as authors, subject, citation, description, etc
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-countries</i18n:text>
                 </h5>
                 <xsl:for-each select="dim:field[@element='cplace' and @qualifier='country' ]">
-                    <a target="_black" >
+                    <a target="_blank" >
                         <xsl:attribute name="href">
                             <xsl:value-of select="concat($context-path,'/discover?filtertype=country&amp;filter_relational_operator=equals&amp;filter=',url:encode(node()))"></xsl:value-of>
                         </xsl:attribute>
@@ -559,7 +559,7 @@ such as authors, subject, citation, description, etc
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-regions</i18n:text>
                 </h5>
                 <xsl:for-each select="dim:field[@element='rplace' and @qualifier='region' ]">
-                    <a target="_black" >
+                    <a target="_blank" >
                         <xsl:attribute name="href">
                             <xsl:value-of select="concat($context-path,'/discover?filtertype=region&amp;filter_relational_operator=equals&amp;filter=',url:encode(node()))"></xsl:value-of>
                         </xsl:attribute>
@@ -596,7 +596,7 @@ such as authors, subject, citation, description, etc
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type</i18n:text>
                 </h5>
                 <xsl:for-each select="dim:field[@element='type']">
-                    <a target="_black" >
+                    <a target="_blank" >
                         <xsl:attribute name="href">
                             <xsl:value-of select="concat($context-path,'/discover?filtertype=type&amp;filter_relational_operator=equals&amp;filter=',url:encode(node()))"></xsl:value-of>
                         </xsl:attribute>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
@@ -100,7 +100,7 @@
 
                     </div>
                     <div >
-                        <span class="descriptionlabel" >Authors :</span>
+                        <span class="descriptionlabel" >Authors:</span>
                         <span class="description-info">
                             <xsl:choose>
                                 <xsl:when test="dri:list[@n=(concat($handle, ':dc.contributor.author'))]">
@@ -152,7 +152,7 @@
 
                         <xsl:if test="dri:list[@n=(concat($handle, ':dc.date.issued'))]">
                             <div>
-                                <span class="descriptionlabel">Date :</span>
+                                <span class="descriptionlabel">Date:</span>
 
                                 <span class="date">
                                     <xsl:value-of
@@ -164,14 +164,14 @@
                         <xsl:if test="dri:list[@n=(concat($handle, ':dc.type'))]">
                             <xsl:variable name="type" select="dri:list[@n=(concat($handle, ':dc.type'))]/dri:item"/>
                             <div class="artifact-type">
-                                <span class="descriptionlabel">Type :</span>
+                                <span class="descriptionlabel">Type:</span>
                                 <xsl:value-of select="$type"/>
                             </div>
                         </xsl:if>
                         <xsl:if test="dri:list[@n=(concat($handle, ':dc.identifier.status'))]">
                             <xsl:variable name="status" select="dri:list[@n=(concat($handle, ':dc.identifier.status'))]/dri:item"/>
                             <div class="artifact-type">
-                                <span class="descriptionlabel">Status :</span>
+                                <span class="descriptionlabel">Status:</span>
                                 <xsl:value-of select="$status"/>
                             </div>
                         </xsl:if>


### PR DESCRIPTION
Fixes unnecessary white space in item lists and corrects link targets from `_black` to `_blank`.
