### PR TITLE
Tweak item display

### DIFF
--- a/dspace/config/modules/altmetrics.cfg
+++ b/dspace/config/modules/altmetrics.cfg
@@ -16,7 +16,7 @@
 altmetric.enabled = true
 
 # Possible values: donut medium-donut large-donut 1 4
-altmetric.badgeType = donut
+altmetric.badgeType = medium-donut
 
 # Possible values: left right top bottom
 altmetric.popover = right

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -664,42 +664,42 @@ such as authors, subject, citation, description, etc
                 <xsl:attribute name="href"><xsl:text>https://twitter.com/home?status=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Tweet this</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
-                <span class="fa fa-twitter-square fa-lg"></span>
+                <span class="fa fa-twitter-square fa-2x"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://www.facebook.com/sharer/sharer.php?u=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share on Facebook</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
-                <span class="fa fa-facebook-square fa-lg"></span>
+                <span class="fa fa-facebook-square fa-2x"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://plus.google.com/share?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share on Google+</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
-                <span class="fa fa-google-plus-square fa-lg"></span>
+                <span class="fa fa-google-plus-square fa-2x"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://www.linkedin.com/shareArticle?mini=true&amp;url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share on LinkedIn</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
-                <span class="fa fa-linkedin-square fa-lg"></span>
+                <span class="fa fa-linkedin-square fa-2x"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://delicious.com/save?v=5&amp;provider=CGSpace&amp;noui&amp;jump=close&amp;url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Save this on Delicious</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>_blank</xsl:text></xsl:attribute>
-                <span class="fa fa-delicious fa-lg"></span>
+                <span class="fa fa-delicious fa-2x"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://www.mendeley.com/import/?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Add this article to your Mendeley library</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
-                <span class="ai ai-mendeley-square ai-lg"></span>
+                <span class="ai ai-mendeley-square ai-2x"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>mailto:?&amp;body=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/><xsl:text>&amp;media=&amp;description=</xsl:text></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share via e-mail</xsl:text></xsl:attribute>
-                <span class="fa fa-envelope fa-lg"></span>
+                <span class="fa fa-envelope fa-2x"></span>
             </a>
         </div>
     </xsl:template>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
@@ -120,19 +120,12 @@
                         </div>
                      </div>
                     <xsl:call-template name="itemSummaryView-DIM-authors"/>
-                    <xsl:call-template name="itemSummaryView-DIM-subjects"/>
-                    <xsl:call-template name="itemSummaryView-DIM-countries"/>
-                    <xsl:call-template name="itemSummaryView-DIM-regions"/>
                     <xsl:call-template name="itemSummaryView-DIM-date"/>
                     <xsl:call-template name="itemSummaryView-DIM-language"/>
                     <xsl:call-template name="itemSummaryView-DIM-type"/>
                     <xsl:call-template name="itemSummaryView-DIM-review-status"/>
                     <xsl:call-template name="itemSummaryView-DIM-accessibility"/>
 
-
-                    <xsl:if test="dim:field[@element='identifier' and @qualifier='uri']">
-                        <xsl:call-template name='itemSummaryView-sharing'/>
-                    </xsl:if>
 
                     <xsl:if test="$ds_item_view_toggle_url != ''">
                         <xsl:call-template name="itemSummaryView-show-full"/>
@@ -144,11 +137,18 @@
 
                 </div>
                 <div class="col-sm-8">
+                    <xsl:if test="dim:field[@element='identifier' and @qualifier='uri']">
+                        <xsl:call-template name='itemSummaryView-sharing'/>
+                    </xsl:if>
+
                     <xsl:call-template name="itemSummaryView-DIM-citation"/>
                     <xsl:call-template name="itemSummaryView-DIM-abstract"/>
                     <xsl:call-template name="itemSummaryView-DIM-notes"/>
                     <xsl:call-template name="itemSummaryView-DIM-affiliations"/>
                     <xsl:call-template name="itemSummaryView-DIM-subject"/>
+                    <xsl:call-template name="itemSummaryView-DIM-subjects"/>
+                    <xsl:call-template name="itemSummaryView-DIM-countries"/>
+                    <xsl:call-template name="itemSummaryView-DIM-regions"/>
                     <xsl:call-template name="itemSummaryView-DIM-investors-sponsors"/>
                     <xsl:call-template name="itemSummaryView-DIM-identifiers"/>
                     <xsl:call-template name="itemSummaryView-DIM-related-material"/>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
@@ -119,6 +119,11 @@
                             <xsl:call-template name="itemSummaryView-DIM-file-section"/>
                         </div>
                      </div>
+
+                    <xsl:if test="confman:getProperty('altmetrics', 'altmetric.enabled') and ($identifier_doi or $identifier_handle)">
+                        <xsl:call-template name='impact-altmetric'/>
+                    </xsl:if>
+
                     <xsl:call-template name="itemSummaryView-DIM-authors"/>
                     <xsl:call-template name="itemSummaryView-DIM-date"/>
                     <xsl:call-template name="itemSummaryView-DIM-language"/>
@@ -129,10 +134,6 @@
 
                     <xsl:if test="$ds_item_view_toggle_url != ''">
                         <xsl:call-template name="itemSummaryView-show-full"/>
-                    </xsl:if>
-
-                    <xsl:if test="confman:getProperty('altmetrics', 'altmetric.enabled') and ($identifier_doi or $identifier_handle)">
-                        <xsl:call-template name='impact-altmetric'/>
                     </xsl:if>
 
                 </div>


### PR DESCRIPTION
Move countries, regions, subjects, and sharing buttons to center and move Altmetric donut up.
