### PR TITLE
Add controlled vocabulary for Subregion (dc.srplace.subregion)

### DIFF
--- a/dspace/config/controlled-vocabularies/dc-srplace-subregion.xml
+++ b/dspace/config/controlled-vocabularies/dc-srplace-subregion.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Subregions need to be defined both here and in input-forms.xml (for Atmire L&R) -->
+<node id="Subregion" label="">
+  <isComposedBy>
+    <node label="AFAR" />
+    <node label="AMHARA" />
+    <node label="ANDHRA PRADESH" />
+    <node label="BENISHANGUL-GUMUZ" />
+    <node label="BIHAR" />
+    <node label="GAMBELA" />
+    <node label="HARARI" />
+    <node label="KARNATAKA" />
+    <node label="OROMIA" />
+    <node label="MADHYA PRADESH" />
+    <node label="MAHARASHTRA" />
+    <node label="NAGALAND" />
+    <node label="SOMALI" />
+    <node label="SNNPR" />
+    <node label="TIGRAY" />
+    <node label="UTTARAKHAND" />
+    <node label="UTTAR PRADESH" />
+  </isComposedBy>
+</node>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -293,7 +293,8 @@
           <dc-qualifier>subregion</dc-qualifier>
           <repeatable>true</repeatable>
           <label>Sub Region Focus</label>
-          <input-type value-pairs-name="subregion_types">dropdown</input-type>
+          <input-type>onebox</input-type>
+          <vocabulary>dc-srplace-subregion</vocabulary>
           <hint>Select the sub-regional focus</hint>
           <required></required>
         </field>


### PR DESCRIPTION
We still need to have these defined in input-forms.xml because the values there are enumerated by Atmire's Listings and Reports module.
