### PR TITLE
input-forms.xml: Adjust author hint

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -43,7 +43,7 @@
           <repeatable>true</repeatable>
           <label>Authors (required)</label>
           <input-type>name</input-type>
-          <hint>Enter the names of the authors of this item. Enter each individually. ALWAYS use the Lookup option to select from an existing author entry (author names in italics have ORCID records)</hint>
+          <hint>Enter the names of individual or full corporate authors of this item. Enter each individually. ALWAYS use the Lookup option to select from an existing author entry (author names in italics have ORCID records)</hint>
           <required>Please enter the author(s).</required>
         </field>
         <field>


### PR DESCRIPTION
Now that dc.contributor.author is used for both individual and full corporate authors, the hint needs to help users understand where to enter them appropriately.
