### PR TITLE
Enable usage of X-Forwarded-For in admin UI

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -229,7 +229,7 @@ log.init.config = ${dspace.dir}/config/log4j.properties
 log.dir = ${dspace.dir}/log
 
 # If enabled, the logging and the solr statistics system will look for
-# an X-Forward header. If it finds it, it will use this for the user IP address
+# an X-Forwarded-For header. If it finds it, it will use this for the user IP address
 useProxies = true
 
 ##### DOI registration agency credentials ######
@@ -2101,7 +2101,7 @@ xmlui.google.analytics.key=UA-10691096-8
 # from. If your DSpace is in a load balanced enviornment or otherwise behind a
 # context-switch then you will need to set the paramater to the HTTP parameter that
 # records the original IP address.
-#xmlui.controlpanel.activity.ipheader = X-Forward-For
+#xmlui.controlpanel.activity.ipheader = X-Forwarded-For
 
 #---------------------------------------------------------------#
 #----------------REQUEST ITEM CONFIGURATION---------------------#

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2101,7 +2101,7 @@ xmlui.google.analytics.key=UA-10691096-8
 # from. If your DSpace is in a load balanced enviornment or otherwise behind a
 # context-switch then you will need to set the paramater to the HTTP parameter that
 # records the original IP address.
-#xmlui.controlpanel.activity.ipheader = X-Forwarded-For
+xmlui.controlpanel.activity.ipheader = X-Forwarded-For
 
 #---------------------------------------------------------------#
 #----------------REQUEST ITEM CONFIGURATION---------------------#


### PR DESCRIPTION
This will show the remote user's real IP address in the activity panel. It was misconfigured and disabled, but still working (for some reason). Better to just fix it and enable to be consistent with stated intent (and since we were kinda relying on it) in case it was a bug or something.
