### PR TITLE
discovery.xml: Fix one more reference to "dc.type.*"

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -661,7 +661,7 @@
         <property name="indexFieldName" value="type"/>
         <property name="metadataFields">
             <list>
-                <value>dc.type.*</value>
+                <value>dc.type</value>
             </list>
         </property>
         <property name="facetLimit" value="10"/>


### PR DESCRIPTION
We migrated all dc.type.\* to dc.type last month so there is no need to index anything but dc.type.
