### PR TITLE
xmlui: Clean up bitstream area under thumbnail of item display

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
@@ -261,7 +261,6 @@
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-viewOpen</i18n:text>
             </h5>
 
-            <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-bitstreams</i18n:text>
             <xsl:variable name="label-1">
                 <xsl:choose>
                     <xsl:when test="confman:getProperty('mirage2.item-view.bitstream.href.label.1')">


### PR DESCRIPTION
Users don't need to know what a "Bitstream" is, so let's just not show it. Looks good:

![screen shot 2016-08-10 at 13 07 35-fullpage-fs8](https://cloud.githubusercontent.com/assets/191754/17550210/8c997c7e-5efc-11e6-848f-d3254286b4fd.png)
