### PR TITLE
discovery.xml: Add title to search filters

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -128,6 +128,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterTitle"/>
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterSponsorship" />
@@ -264,6 +265,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterTitle"/>
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />
                 <ref bean="searchFilterSponsorship" />


### PR DESCRIPTION
It's not great but users have been asking for a way to search by title. I think DSpace searches with OR by default, which makes searches with many terms return too many results.

Part of the work needed for #270.
