### PR TITLE
Change default Solr search boolean logic from OR to AND

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -633,7 +633,7 @@
  <defaultSearchField>search_text</defaultSearchField>
 
  <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
+ <solrQueryParser defaultOperator="AND"/>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,


### PR DESCRIPTION
This should make searches with more terms narrow the search results instead of increasing them (like Google does). Users have come to expect this behavior and this is now the default in DSpace 6.0.

See: https://jira.duraspace.org/browse/DS-2809
