### PR TITLE
Add dc.date.accessioned to Discovery search filters

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -128,6 +128,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterDateAccessioned" />
                 <ref bean="searchFilterTitle"/>
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />
@@ -265,6 +266,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterAffiliation" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterDateAccessioned" />
                 <ref bean="searchFilterTitle"/>
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterCrpsubject" />

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -419,6 +419,7 @@
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.breed">Animal breed</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.species">Species</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.sponsorship">Investor</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateAccessioned">Date accessioned</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">This resource is restricted</message>


### PR DESCRIPTION
Many users want a way to filter search results by accession date.
