### PR TITLE
Clean up discovery.xml

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -483,7 +483,7 @@
                 <value>cg.identifier.status</value>
             </list>
         </property>
-        <property name="facetLimit" value="5"/>
+        <property name="facetLimit" value="2"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -471,7 +471,6 @@
                 <value>dc.date.issued</value>
             </list>
         </property>
-        <property name="facetLimit" value="10"/>
         <property name="type" value="date"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>


### PR DESCRIPTION
A few improvements to `discovery.xml` after reading the DSpace manual:
- Don't use `facetLimit` for date facets (they are automatically grouped by year, regardless of this setting)
- Set lower `facetLimit` for accessibility status facet, as we only expect two values there, and anything else is an error and should not be displayed
- ~~Use `DiscoverySearchFilter` class for filters that aren't being used as facets~~
