### PR TITLE
Statistics/messages.xml: Fix reference to dc.type.*

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/aspects/Statistics/messages.xml
@@ -584,7 +584,7 @@ DAMAGE.
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.dc.title">Title (dc.title)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.dc.type.template">Type Template (dc.type.template)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.dc.type">Type (dc.type)</message>
-    <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.type">Type (dc.type.*)</message>
+    <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.type">Type (dc.type)</message>
 
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.status">Status (cg.identifier.status)</message>
     <message key="xmlui.reporting-suite.statistics.graph-editor.data-source.dataset.option.isijournal">ISI journal (cg.isijournal)</message>
@@ -977,7 +977,7 @@ DAMAGE.
     <message key="xmlui.metadataquality.batch-edit.field.label.dc.title.alternative">Alternative Title (dc.title.alternative)</message>
     <message key="xmlui.metadataquality.batch-edit.field.label.dc.title">Title (dc.title)</message>
     <message key="xmlui.metadataquality.batch-edit.field.label.dc.type.template">Type Template (dc.type.template)</message>
-    <message key="xmlui.metadataquality.batch-edit.field.label.dc.type">Type (dc.type.*)</message>
+    <message key="xmlui.metadataquality.batch-edit.field.label.dc.type">Type (dc.type)</message>
     <message key="xmlui.metadataquality.batch-edit.field.label.workflow.batchedit.claimedby">Batch edit step claimed user identifier (workflow.batchedit.claimedby)</message>
 
 


### PR DESCRIPTION
We changed the index for "Output type" from dc.type.\* to dc.type several months ago, so this should reflect that.
