### PR TITLE
Add disclaimer text to About page

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure.xsl
@@ -801,6 +801,8 @@
                                 <li>Chris Addison (CTA) ― identified CGSpace as a suitable platform to host archive, and now also current, content from CTA.</li>
                                 <li>Bizuwork Mulat, Abeba Desta and Goshu Cherinet (ILRI), Megan Zandstra and Leroy Mwanzia (CIAT), Udana Ariyawansa and Chandima Gunadasa (IWMI), Sufiet Erlita (CIFOR), Joel Ranck and Cecilia Ferreyra (CIP), Maria Garruccio (Bioversity), Martin Mueller (IITA), Ryan Miller (IFPRI), Thierry Lewyllie (CTA) and Daniel Haile-Michael and Tsega Tassema (ILRI web team) all brought their specific expertise and dedication to help move the collaboration forward.</li>
                               </ul>
+					  <h2>Disclaimer</h2>
+					    <p>CGSpace content providers and partners accept no liability to any consequence resulting from use of the content or data made available in this repository. Users of this content assume full responsibility for compliance with all relevant national or international regulations and legislation.</p>
                         
                     </div>
                 </xsl:when>


### PR DESCRIPTION
Bare minimum for #234. Would have liked to put a link in the footer that jumps to this header on the About page, but there is a bug in Bootstrap (see #234 for discussion).
