### PR TITLE
dspace/config/dspace.cfg: Update consumers for Atmire MQM

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -799,7 +799,7 @@ event.consumer.authority.filters = Item+Modify|Modify_Metadata
 
 ## MQM Consumers
 event.consumer.batchedit.class = com.atmire.metadataquality.batchedit.BatchEditConsumer
-event.consumer.batchedit.filters = Community|Collection|Item|Bundle+Add|Create|Modify|Modify_Metadata|Delete|Remove|Add_To_Batch_Task
+event.consumer.batchedit.filters = Community|Collection+Create
 
 event.consumer.versioningmqm.class = com.atmire.versioning.ModificationConsumer
 event.consumer.versioningmqm.filters = Item+Add|Create|Modify|Modify_Metadata|Delete|Remove


### PR DESCRIPTION
According to Atmire we need to adjust the consumers for the MQM module because newer versions respond to fewer events. This should stop some of the WARN log spam we get.