### PR TITLE
Ugly hack to fix "take task" issue in DSpace > 5.4

### DIFF
--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -98,6 +98,10 @@ public class WorkflowItem implements InProgressSubmission
         WorkflowItem fromCache = (WorkflowItem) context.fromCache(
                 WorkflowItem.class, id);
 
+        // Ugly hack to fix issue with "take task" by skipping the cache
+        // See: https://jira.duraspace.org/browse/DS-2920
+        fromCache = null;
+
         if (fromCache != null)
         {
             return fromCache;


### PR DESCRIPTION
The bug happens when non-admin users try to take a task from the submissions pool. This hack nullifies the cache so that permissions are always retrieved from the database. Not an official fix!

See: https://jira.duraspace.org/browse/DS-2920