### PR TITLE
atmire-cua.cfg: Use variable interpolation for last update var

### DIFF
--- a/dspace/config/modules/atmire-cua.cfg
+++ b/dspace/config/modules/atmire-cua.cfg
@@ -163,7 +163,7 @@ storage.number.of.results.per.page = 10
 #---------------------------------------------------------#
 
 # File that holds the timestamp of the last update of item's metadata in solr stats.
-metadata.update.timestamp.file = /Users/art/Development/dspaces/dspace4-cua4/config/last-update.txt
+metadata.update.timestamp.file = ${dspace.dir}/config/last-update.txt
 
 #metadata.item.1=author:dc.contributor.author
 #metadata.item.2=subject:dc.subject


### PR DESCRIPTION
A path was accidentally hardcoded here, causing the following error to be printed in the logs after each stats update:

```
2016-11-29 07:14:08,874 ERROR com.atmire.utils.UpdateSolrStatsMetadata @ java.io.FileNotFoundException: /Users/art/Development/dspaces/dspace4-cua4/config/last-update.txt (No such file or directory)
```

It doesn't seem to cause any issues, as it's been there for almost a year and nobody noticed. I only noticed because I saw errors in the log files.