### PR TITLE
Use semicolon as author separator on XMLUI lists

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-list-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-list-alterations.xsl
@@ -95,7 +95,7 @@
                                     </a>
                                 </span>
                                 <xsl:if test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author']) != 0">
-                                    <xsl:text>, </xsl:text>
+                                    <xsl:text>; </xsl:text>
                                 </xsl:if>
 
                             </xsl:for-each>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
@@ -120,7 +120,7 @@
                                             </a>
                                         </span>
                                         <xsl:if test="count(following-sibling::dri:item) != 0">
-                                            <xsl:text>, </xsl:text>
+                                            <xsl:text>; </xsl:text>
                                         </xsl:if>
 
                                     </xsl:for-each>


### PR DESCRIPTION
Author names often have "," in them so we should use something else to separate names on XMLUI items lists.