### PR TITLE
xmlui: Bump academicons to 1.8.0

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
@@ -13,7 +13,7 @@
     "holderjs": "2.4.1",
     "chartist" :"0.9.4",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0",
+    "academicons": "1.8.0",
     "datatables": "1.10.3"
   },
   "devDependencies": {}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
@@ -5,7 +5,7 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.6.0"
+    "academicons": "1.8.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
They somehow deleted the old 1.6.0 tag, so builds are failing.