### PR TITLE
Add cg.contributor.affiliation to Listings and Reports

### DIFF
--- a/dspace/config/modules/atmire-listings-and-reports.cfg
+++ b/dspace/config/modules/atmire-listings-and-reports.cfg
@@ -47,6 +47,7 @@ biblio.filtertype.19 = humidtropics, valuepairs, jsp.export.filter-categories.hu
 biblio.filtertype.20 = Review_status, valuepairs, jsp.export.filter-categories.version, dc.description.version, true, dc.description.version
 biblio.filtertype.21 = ispartofseries, input, jsp.export.filter-categories.ispartofseries, dc.relation.ispartofseries, false, dc.relation.ispartofseries
 biblio.filtertype.22 = publisher, input, jsp.export.filter-categories.publisher, dc.publisher, false, dc.publisher
+biblio.filtertype.23 = affiliation, input, jsp.export.filter-categories.affiliation, cg.contributor.affiliation, false, affiliation
 
 #atmire.process.completion = 5
 

--- a/dspace/modules/additions/src/main/resources/Messages.properties
+++ b/dspace/modules/additions/src/main/resources/Messages.properties
@@ -2219,3 +2219,4 @@ jsp.export.filter-categories.humidtropics = Humidtropics subject
 jsp.export.filter-categories.version = Peer reviewed status
 jsp.export.filter-categories.ispartofseries = Series name and number
 jsp.export.filter-categories.publisher = Publisher
+jsp.export.filter-categories.affiliation = Affiliation


### PR DESCRIPTION
For some reason there are no results returned if the last parameter is cg.contributor.affiliation (as it's supposed to be the name of and index in Discovery), because the existing fields work!