### PR TITLE
Remove UKaid from sponsors vocabulary

### DIFF
--- a/dspace/config/controlled-vocabularies/dc-description-sponsorship.xml
+++ b/dspace/config/controlled-vocabularies/dc-description-sponsorship.xml
@@ -124,7 +124,6 @@
     <node label="Syngenta Foundation for Sustainable Agriculture" />
     <node label="Technical Centre for Agricultural and Rural Cooperation" />
     <node label="U.S. Agency for International Development" />
-    <node label="UKAid" />
     <node label="United Nations Development Programme" />
     <node label="United Nations Environment Programme" />
     <node label="United States Agency for International Development" />


### PR DESCRIPTION
UKaid is just a brand, the correct name for this is "Department for International Development, United Kingdom".