### PR TITLE
dspace-services: Disable update check in ehcache

### DIFF
--- a/dspace-services/src/main/resources/caching/ehcache-config.xml
+++ b/dspace-services/src/main/resources/caching/ehcache-config.xml
@@ -8,7 +8,7 @@
     http://www.dspace.org/license/
 
 -->
-<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="ehcache.xsd">
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="ehcache.xsd" updateCheck="false">
 
     <!-- Sets the path to the directory where cache .data files are created.
 


### PR DESCRIPTION
Some DSpace components rely on an upstream project called Ehcache which has the unfortunate policy of calling home to check if there are any updates every time it is invoked. The update call includes lots of information about the server environment, including the OS and Java versions, and of course the IP address of the server.

In addition to this being a jarring leak of privacy, it is also not very effective, as the DSpace user is not in control of the version of Ehcache being used! Furthermore, some parts of the DSpace code will invoke this code hundreds of times, for example in AIP ingest, and it's mind boggling that there should be a call to what amounts to be a random server on the Internet (as far as the DSpace site's
owner is concerned).

There is an issue on the upstream project's bug tracker where they have said they will not fix it, so we will just disable it locally.

See: https://jira.terracotta.org/jira/browse/EHC-461