### PR TITLE
Resolve CGIAR Library handles

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -352,7 +352,7 @@ handle.dir = ${dspace.dir}/handle-server
 # List any additional prefixes that need to be managed by this handle server 
 # (as for examle handle prefix coming from old dspace repository merged in 
 # that repository)
-# handle.additional.prefixes = prefix1[, prefix2]  
+handle.additional.prefixes = 10947
 
 # By default we hide the list handles method in the JSON endpoint as it could 
 # produce heavy load for large repository 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -354,6 +354,9 @@ handle.dir = ${dspace.dir}/handle-server
 # that repository)
 handle.additional.prefixes = 10947
 
+# Allow DSpace to resolve handles from multiple prefixes (see HandlePlugin.java)
+handle.plugin.checknameauthority = false
+
 # By default we hide the list handles method in the JSON endpoint as it could 
 # produce heavy load for large repository 
 # handle.hide.listhandles = false


### PR DESCRIPTION
Allow CGSpace to resolve handle prefixes other than its "main" one, as we are soon going to migrate all of the CGIAR Library's content into CGSpace and will need to be able to resolve its handles with prefix 10947.

This is a fairly unknown functionality of DSpace and relies on an undocumented configuration option found in `HandlePlugin.java`. There are also some changes required to the DSpace Handle server's `config.dct` for this to work, after which we need to regenerate the `sitebndl.zip` and send it to to the Handle.net admins.

- See: http://dspace.2283337.n4.nabble.com/Multiple-handle-prefixes-merged-DSpace-instances-td3427192.html
- See: https://wiki.duraspace.org/display/DSDOC5x/Installing+DSpace?focusedCommentId=78163296#comment-78163296