### PR TITLE
xmlui: Add verification file for CGIAR Library

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/google31ea257b2e1fdfeb.html
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/google31ea257b2e1fdfeb.html
@@ -1,0 +1,1 @@
+google-site-verification: google31ea257b2e1fdfeb.html


### PR DESCRIPTION
The Google Search Console needs this to be able to add a new property for the library.cgiar.org domains. This file will be copied into the theme directory during build time, then we can access it via an nginx alias.