### PR TITLE
Add index for CGIAR System subject

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1187,6 +1187,7 @@ webui.browse.index.18 = bioversity:metadata:cg.subject.bioversity:text
 webui.browse.index.19 = ciat:metadata:cg.subject.ciat:text
 webui.browse.index.20 = cipsubject:metadata:cg.subject.cip:text
 webui.browse.index.21 = breed:metadata:cg.species.breed:text
+webui.browse.index.22 = systemsubject:metadata:cg.subject.system:text
 
 ## example of authority-controlled browse category - see authority control config
 #webui.browse.index.5 = lcAuthor:metadataAuthority:dc.contributor.author:authority

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -776,6 +776,18 @@
         <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
 
+    <bean id="searchFilterSystemSubject" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="systemsubject"/>
+        <property name="metadataFields">
+            <list>
+                <value>cg.subject.system</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+    </bean>
+
     <bean id="searchFilterAffiliation" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="affiliation"/>
         <property name="metadataFields">
@@ -872,6 +884,7 @@
                 <ref bean="searchFilterCipSubject"/>
                 <ref bean="searchFilterDrylandsSubject"/>
                 <ref bean="searchFilterIcardaSubject"/>
+                <ref bean="searchFilterSystemSubject"/>
             </list>
         </property>
         <!--The sort filters for the discovery search-->

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -212,6 +212,7 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.basin.column_heading">River basin</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.cipsubject.column_heading">CIP subject</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.breed.column_heading">Animal breed</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.systemsubject.column_heading">CGIAR System subject</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.region.column_heading">Region</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subregion.column_heading">Subregion</message>
@@ -271,6 +272,8 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.cipsubject">Browsing {0} by CIP subject</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.breed">Browsing {0} by animal breed {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.breed">Browsing {0} by animal breed</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.systemsubject">Browsing {0} by CGIAR System subject {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.systemsubject">Browsing {0} by CGIAR System subject</message>
 
 	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
 	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
@@ -385,6 +388,7 @@
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_type">By Output type</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_cipsubject">By CIP subject</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_breed">By animal breed</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_systemsubject">By CGIAR System subject</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Search</message>


### PR DESCRIPTION
When we migrated the CGIAR Library to CGSpace in 2017-09 we moved their dc.subject metadata to cg.subject.system. Their website has many links to browse and search results for these subjects so we need to accommodate them somehow. I will capture browse requests for "type=subject" in nginx and redirect them to the new index (systemsubject).