### PR TITLE
input-forms.xml: Add missing CCAFS Phase II Project Tags

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -3629,6 +3629,14 @@
     </value-pairs>
     <value-pairs value-pairs-name="ccafsprojectpii" dc-term="ccafsprojectpii">
       <pair>
+        <displayed-value>PII-EA_CSV</displayed-value>
+        <stored-value>PII-EA_CSV</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>PII-EA_Partnerships</displayed-value>
+        <stored-value>PII-EA_Partnerships</stored-value>
+      </pair>
+      <pair>
         <displayed-value>PII-FP1_CIATLAM</displayed-value>
         <stored-value>PII-FP1_CIATLAM</stored-value>
       </pair>


### PR DESCRIPTION
I'm not sure how we missed these, but PII-EA_CSV and PII-EA_Partnerships are both missing.