### PR TITLE
Clicking thumbnails on item view should navigate to the content bitstream

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -179,6 +179,10 @@ width:85%
   border:0;
   margin-left: 0;
 }
+.thumbnail a {
+  /* clickable area of thumbnails should not fill the entire area of the parent div */
+  display: inline-block;
+}
 .auto-open-statlets #aspect_statistics_StatletTransformer_div_showStats{
   display: none;
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -177,6 +177,7 @@ width:85%
 .thumbnail>img, .thumbnail a>img{
   width: 128px;
   border:0;
+  margin-left: 0;
 }
 .auto-open-statlets #aspect_statistics_StatletTransformer_div_showStats{
   display: none;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
@@ -201,10 +201,14 @@
     <xsl:template name="itemSummaryView-DIM-thumbnail">
         <div class="thumbnail">
             <xsl:choose>
+                <!-- Alan: check if there is a thumbnail and that the link is allowed -->
                 <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='THUMBNAIL'] and not(contains(//mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href,'isAllowed=n'))">
+                    <!-- Alan: start determining the value of the src variable -->
                     <xsl:variable name="src">
                         <xsl:choose>
+                            <!-- Alan: check if groupid for thumbnail is the same as that of the first content bitstream -->
                             <xsl:when test="/mets:METS/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file[@GROUPID=../../mets:fileGrp[@USE='CONTENT']/mets:file[@GROUPID=../../mets:fileGrp[@USE='THUMBNAIL']/mets:file/@GROUPID][1]/@GROUPID]">
+                                <!-- Alan: select the URL of the thumbnail -->
                                 <xsl:value-of
                                         select="/mets:METS/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file[@GROUPID=../../mets:fileGrp[@USE='CONTENT']/mets:file[@GROUPID=../../mets:fileGrp[@USE='THUMBNAIL']/mets:file/@GROUPID][1]/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
                             </xsl:when>
@@ -214,11 +218,17 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:variable>
-                    <img alt="Thumbnail">
-                        <xsl:attribute name="src">
-                            <xsl:value-of select="$src"/>
+                    <a>
+                        <xsl:attribute name="href">
+                            <xsl:value-of select="//mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
                         </xsl:attribute>
-                    </img>
+
+                        <img alt="Thumbnail">
+                            <xsl:attribute name="src">
+                                <xsl:value-of select="$src"/>
+                            </xsl:attribute>
+                        </img>
+                    </a>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:choose>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view.xsl
@@ -218,17 +218,31 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:variable>
-                    <a>
-                        <xsl:attribute name="href">
-                            <xsl:value-of select="//mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
-                        </xsl:attribute>
+                    <!-- Alan: if there is a content bitstream, add a link to the thumbnail -->
+                    <xsl:choose>
+                        <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href">
+                            <a>
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="//mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                                </xsl:attribute>
 
-                        <img alt="Thumbnail">
-                            <xsl:attribute name="src">
-                                <xsl:value-of select="$src"/>
-                            </xsl:attribute>
-                        </img>
-                    </a>
+                                <img alt="Thumbnail">
+                                    <xsl:attribute name="src">
+                                        <xsl:value-of select="$src"/>
+                                    </xsl:attribute>
+                                </img>
+                            </a>
+                        </xsl:when>
+                        <!-- Alan: otherwise, just print the thumbnail -->
+                        <xsl:otherwise>
+
+                            <img alt="Thumbnail">
+                                <xsl:attribute name="src">
+                                    <xsl:value-of select="$src"/>
+                                </xsl:attribute>
+                            </img>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:choose>


### PR DESCRIPTION
This has been highlighted by users as something that would make CGSpace easier to use. If an item has a bitstream in its content bundle then clicking the thumbnail should take you to it. I left some comments in the code as a tip for understanding what is going on in the XSL.