### PR TITLE
DS-3583: Usage of correct Collection Array

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -733,7 +733,7 @@ public class ItemImport
                 {
                     clist = mycollections;
                 }
-                addItem(c, mycollections, sourceDir, dircontents[i], mapOut, template);
+                addItem(c, clist, sourceDir, dircontents[i], mapOut, template);
                 System.out.println(i + " " + dircontents[i]);
                 c.clearCache();
             }


### PR DESCRIPTION
The dspace import function currently throws a NullPointerException when trying to import items from a Simple Archive Format (SAF) bundle if you do not specify the collection on the command line.

The issue was fixed in DSpace 5.7 but I am applying it on our 5.5 branch because it's totally lame. Note to self: do not cherry-pick this when I rebase our branch on top of the latest upstream 5.x branch later!

See: https://jira.duraspace.org/browse/DS-3583
See: https://github.com/DSpace/DSpace/pull/1731