### PR TITLE
Disable ORCID authority

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1637,8 +1637,8 @@ sherpa.romeo.url = http://www.sherpa.ac.uk/romeo/api29.php
 #  org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 #Uncomment to enable ORCID authority control
-plugin.named.org.dspace.content.authority.ChoiceAuthority = \
-    org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
+#plugin.named.org.dspace.content.authority.ChoiceAuthority = \
+    # org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 ## The DCInputAuthority plugin is automatically configured with every
 ## value-pairs element in input-forms.xml, namely:
@@ -1675,16 +1675,16 @@ plugin.named.org.dspace.content.authority.ChoiceAuthority = \
 ##   novalue
 ##   unset
 ## See manual or org.dspace.content.authority.Choices source for descriptions.
-authority.minconfidence = ambiguous
+# authority.minconfidence = ambiguous
 
 # Configuration settings for ORCID based authority control, uncomment the lines below to enable configuration
-solr.authority.server=${solr.server}/authority
-choices.plugin.dc.contributor.author = SolrAuthorAuthority
-choices.presentation.dc.contributor.author = authorLookup
-authority.controlled.dc.contributor.author = true
-authority.author.indexer.field.1=dc.contributor.author
-authority.author.indexer.field.2=dc.creator
-authority.author.indexer.field.3=dc.contributor
+#solr.authority.server=${solr.server}/authority
+#choices.plugin.dc.contributor.author = SolrAuthorAuthority
+#choices.presentation.dc.contributor.author = authorLookup
+#authority.controlled.dc.contributor.author = true
+#authority.author.indexer.field.1=dc.contributor.author
+#authority.author.indexer.field.2=dc.creator
+#authority.author.indexer.field.3=dc.contributor
 
 ## demo: use LC plugin for author
 #choices.plugin.dc.contributor.author =  LCNameAuthority

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -193,7 +193,6 @@ width:85%
   width:20px;
 }
 
-.ds-dc_contributor_author-authority,
 .ds-cg_creator_orcid {
   margin-bottom: 2px;
   margin-top: 2px;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-list-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-list-alterations.xsl
@@ -78,11 +78,6 @@
                         <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
                             <xsl:for-each select="dim:field[@element='contributor'][@qualifier='author']">
                                 <span>
-                                    <xsl:if test="@authority">
-                                        <xsl:attribute name="class">
-                                            <xsl:text>ds-dc_contributor_author-authority</xsl:text>
-                                        </xsl:attribute>
-                                    </xsl:if>
                                     <xsl:variable name="authorLink">
                                         <xsl:value-of
                                                 select="concat($context-path,'/discover?filtertype=author&amp;filter_relational_operator=equals&amp;filter=',url:encode(node()))"></xsl:value-of>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -249,27 +249,9 @@ such as authors, subject, citation, description, etc
 
     <xsl:template name="itemSummaryView-DIM-authors-entry">
         <div>
-            <xsl:if test="@authority">
-                <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
-            </xsl:if>
             <xsl:call-template name="discovery-link">
                 <xsl:with-param name="filtertype" select="'author'"/>
             </xsl:call-template>
-
-            <xsl:if test="@authority">
-	            <xsl:variable name="authority" select="@authority"/>
-
-	            <xsl:if test="../dim:field[@authority=$authority and @mdschema='atmire' and @element='orcid' and @qualifier='id']">
-		            <a class="orcid-icon-link" target="_blank">
-			            <xsl:attribute name="href">
-				            <xsl:value-of select="concat('//orcid.org/', ../dim:field[@authority=$authority and @mdschema='atmire' and @element='orcid' and @qualifier='id']/text())"/>
-			            </xsl:attribute>
-
-			            <img alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt"
-			                 src="{concat($theme-path, 'images/mini-icon.png')}"/>
-		            </a>
-	            </xsl:if>
-            </xsl:if>
         </div>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/discovery/discovery-item-list-alterations.xsl
@@ -106,9 +106,6 @@
                                 <xsl:when test="dri:list[@n=(concat($handle, ':dc.contributor.author'))]">
                                     <xsl:for-each select="dri:list[@n=(concat($handle, ':dc.contributor.author'))]/dri:item">
                                         <span>
-                                            <xsl:if test="@authority">
-                                                <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
-                                            </xsl:if>
                                             <xsl:variable name="authorLink">
                                                 <xsl:value-of select="concat($context-path,'/discover?filtertype=author&amp;filter_relational_operator=equals&amp;filter=',url:encode(node()))"></xsl:value-of>
                                             </xsl:variable>


### PR DESCRIPTION
In 2018-02 ORCID disabled their version 1 API and DSpace's integration broke. We've since moved to using standard metadata to store ORCID identifiers in the `cg.creator.id` field. This removes the ORCID authority integration with `dc.contributor.author` as well as related display code from XMLUI.