### PR TITLE
Remove Humidtropics from Listings and Reports

### DIFF
--- a/dspace/config/modules/atmire-listings-and-reports.cfg
+++ b/dspace/config/modules/atmire-listings-and-reports.cfg
@@ -43,11 +43,10 @@ biblio.filtertype.15 = journaltitle, input, jsp.export.filter-categories.journal
 biblio.filtertype.16 = ISI_Journal, valuepairs, jsp.export.filter-categories.isijournal, cg.isijournal, true, cg.isijournal
 biblio.filtertype.17 = bioversity, valuepairs, jsp.export.filter-categories.bioversity, cg.subject.bioversity, true, cg.subject.bioversity
 biblio.filtertype.18 = ciat, valuepairs, jsp.export.filter-categories.ciat, cg.subject.ciat, true, cg.subject.ciat
-biblio.filtertype.19 = humidtropics, valuepairs, jsp.export.filter-categories.humidtropics, cg.subject.humidtropics, true, cg.subject.humidtropics
-biblio.filtertype.20 = Review_status, valuepairs, jsp.export.filter-categories.version, dc.description.version, true, dc.description.version
-biblio.filtertype.21 = ispartofseries, input, jsp.export.filter-categories.ispartofseries, dc.relation.ispartofseries, false, dc.relation.ispartofseries
-biblio.filtertype.22 = publisher, input, jsp.export.filter-categories.publisher, dc.publisher, false, dc.publisher
-biblio.filtertype.23 = affiliation, input, jsp.export.filter-categories.affiliation, cg.contributor.affiliation, false, affiliation
+biblio.filtertype.19 = Review_status, valuepairs, jsp.export.filter-categories.version, dc.description.version, true, dc.description.version
+biblio.filtertype.20 = ispartofseries, input, jsp.export.filter-categories.ispartofseries, dc.relation.ispartofseries, false, dc.relation.ispartofseries
+biblio.filtertype.21 = publisher, input, jsp.export.filter-categories.publisher, dc.publisher, false, dc.publisher
+biblio.filtertype.22 = affiliation, input, jsp.export.filter-categories.affiliation, cg.contributor.affiliation, false, affiliation
 
 #atmire.process.completion = 5
 


### PR DESCRIPTION
We had removed the associated controlled vocabulary from the input forms a few days ago and Listings and Reports is throwing a null pointer exception because it can't find the terms.