### PR TITLE
Add ORCID identifier to Discovery and Listings and Reports

### DIFF
--- a/dspace/config/modules/atmire-listings-and-reports.cfg
+++ b/dspace/config/modules/atmire-listings-and-reports.cfg
@@ -47,6 +47,7 @@ biblio.filtertype.19 = Review_status, valuepairs, jsp.export.filter-categories.v
 biblio.filtertype.20 = ispartofseries, input, jsp.export.filter-categories.ispartofseries, dc.relation.ispartofseries, false, dc.relation.ispartofseries
 biblio.filtertype.21 = publisher, input, jsp.export.filter-categories.publisher, dc.publisher, false, dc.publisher
 biblio.filtertype.22 = affiliation, input, jsp.export.filter-categories.affiliation, cg.contributor.affiliation, false, affiliation
+biblio.filtertype.23 = orcid, input, jsp.export.filter-categories.orcid, cg.creator.id, false, orcid
 
 #atmire.process.completion = 5
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -152,6 +152,7 @@
                 <ref bean="searchFilterIwmiSubject"/>
                 <ref bean="searchFilterWlesubject"/>
                 <ref bean="searchFilterStatus" />
+                <ref bean="searchFilterOrcid" />
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -291,6 +292,7 @@
                 <ref bean="searchFilterIwmiSubject"/>
                 <ref bean="searchFilterWlesubject"/>
                 <ref bean="searchFilterStatus" />
+                <ref bean="searchFilterOrcid" />
             </list>
         </property>
         <!--The sort filters for the discovery search (same as defaultConfiguration above)-->
@@ -817,6 +819,18 @@
         <property name="metadataFields">
             <list>
                 <value>cg.species.breed</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+    </bean>
+
+    <bean id="searchFilterOrcid" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="orcid"/>
+        <property name="metadataFields">
+            <list>
+                <value>cg.creator.id</value>
             </list>
         </property>
         <property name="facetLimit" value="5"/>

--- a/dspace/modules/additions/src/main/resources/Messages.properties
+++ b/dspace/modules/additions/src/main/resources/Messages.properties
@@ -2220,3 +2220,4 @@ jsp.export.filter-categories.version = Peer reviewed status
 jsp.export.filter-categories.ispartofseries = Series name and number
 jsp.export.filter-categories.publisher = Publisher
 jsp.export.filter-categories.affiliation = Affiliation
+jsp.export.filter-categories.orcid = ORCID identifier

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -421,6 +421,7 @@
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.sponsorship">Investor</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateAccessioned">Date accessioned</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.isijournal">ISI journal</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.orcid">ORCID identifier</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">This resource is restricted</message>


### PR DESCRIPTION
Adds the ability to use the ORCID identifier (cg.creator.id) as a search filter in Discovery and Listings and Reports. Closes #361.