### PR TITLE
dspace.cfg: Remove authority consumer

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -758,7 +758,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Add doi here if you are using org.dspace.identifier.DOIIdentifierProvider to generate DOIs.
 # Adding doi here makes DSpace send metadata updates to your doi registration agency.
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
-event.dispatcher.default.consumers = authority, versioning, discovery, eperson, harvester, statistics,batchedit, versioningmqm
+event.dispatcher.default.consumers = versioning, discovery, eperson, harvester, statistics,batchedit, versioningmqm
 
 event.consumer.statistics.class = org.dspace.statistics.StatisticsLoggingConsumer
 event.consumer.statistics.filters = Community|Collection|Item|Bitstream+Add|Modify_Metadata|Delete|Remove|Modify


### PR DESCRIPTION
We disabled the Authority functionality last month, but we missed this setting. I noticed several of these errors in the DSpace log:

```
2018-04-14 18:55:25,841 ERROR org.dspace.authority.AuthoritySolrServiceImpl @ Authority solr is not correctly configured, check "solr.authority.server" property in the dspace.cfg
java.lang.NullPointerException
```