### PR TITLE
Fix sorting on Atmire Listings and Reports

### DIFF
--- a/dspace/config/modules/atmire-listings-and-reports.cfg
+++ b/dspace/config/modules/atmire-listings-and-reports.cfg
@@ -54,9 +54,9 @@ biblio.filtertype.23 = orcid, input, jsp.export.filter-categories.orcid, cg.crea
 
 ##### Order (or sort by) types for the bibliography generator #####
 # format: biblio.ordertype.[number] = id, propertyKey (for the label), element.qualifier (if the qualifier is null don't put the ".qualifier")
-biblio.ordertype.1 = date, jsp.export.sort.sort-box.date, date.issued
-biblio.ordertype.2 = title, jsp.export.sort.sort-box.by-title, title
-biblio.ordertype.3 = author, jsp.search.advanced.type.author, contributor.author
+biblio.ordertype.1 = date, jsp.export.sort.sort-box.date, dc.date.issued
+biblio.ordertype.2 = title, jsp.export.sort.sort-box.by-title, dc.title
+biblio.ordertype.3 = author, jsp.search.advanced.type.author, dc.contributor.author
 
 
 #Biblio possible displayed metadata fields


### PR DESCRIPTION
The sort fields for Listings and Reports were missing the "dc" schema which caused sorting to not work.