### PR TITLE
xmlui: Enable IP address anonymization in Google Analytics

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure-alterations.xsl
@@ -22,7 +22,9 @@
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
             ga('create', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-            ga('send', 'pageview');
+            ga('send', 'pageview', {
+              'anonymizeIp': true
+            });
             </xsl:text></script>
         </xsl:if>
     </xsl:template>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/xsl/core/page-structure-alterations.xsl
@@ -21,7 +21,9 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+          'anonymizeIp': true
+        });
         </xsl:text></script>
     </xsl:template>
 


### PR DESCRIPTION
For GDPR compliance we need to anonymize the user IP address that we send to Google with analytics.js. This sets the `aip=1` parameter in the protocol request.

See: https://support.google.com/analytics/answer/2763052?hl=en
See: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#anonymizeIp