### PR TITLE
GDPR privacy popup for cookies opt-in

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
@@ -14,7 +14,8 @@
     "chartist" :"0.9.4",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "datatables": "1.10.3"
+    "datatables": "1.10.3",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/scripts.xml
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/scripts.xml
@@ -40,6 +40,8 @@
 	<script src="scripts/templates.js">&#160;</script>
 	<script src="scripts/most-popular.js">&#160;</script>
 	<script src="scripts/auto-open-statlets.js">&#160;</script>
+	<script src="vendor/cookieconsent/build/cookieconsent.min.js">&#160;</script>
+	<script src="scripts/gdpr.js">&#160;</script>
 
 	<!-- authorLookup and its dependencies -->
 	<script src="vendor/datatables/media/js/jquery.dataTables.js">&#160;</script>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/scripts/gdpr.js
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/scripts/gdpr.js
@@ -1,0 +1,33 @@
+// Initialize cookieconsent popup
+// See: https://github.com/insites/cookieconsent
+function initializeCookieConsent() {
+    window.cookieconsent.initialise({
+        "position": "bottom",
+        "type": "opt-in",
+        "content": {
+            "message": "This site uses cookies. By clicking \"agree\" and continuing to use this site you agree to our use of cookies.",
+            "dismiss": "Disagree",
+            "allow": "Agree",
+            "link": "Our privacy statement.",
+            "href": "https://www.ilri.org/privacy-cookies-statement"
+        }
+    });
+};
+
+// Quick function to check cookie status
+// From: https://www.w3schools.com/js/js_cookies.asp
+function getCookie(cname) {
+    var name = cname + "=";
+    var decodedCookie = decodeURIComponent(document.cookie);
+    var ca = decodedCookie.split(';');
+    for(var i = 0; i <ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_cookieconsent.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_cookieconsent.scss
@@ -1,0 +1,59 @@
+@import "../vendor/cookieconsent/src/styles/base.css";
+@import "../vendor/cookieconsent/src/styles/layout.css";
+@import "../vendor/cookieconsent/src/styles/media.css";
+
+.cc-window {
+  background-color: $brand-primary;
+  color: #fcfcfc;
+}
+
+.cc-btn.cc-allow, .cc-btn.cc-allow:hover {
+  color: #fcfcfc;
+  background-color: $brand-secondary;
+  border: none;
+}
+
+.cc-btn.cc-dismiss {
+  color: #fcfcfc;
+}
+
+.cc-link, .cc-link:visited {
+  color: inherit;
+}
+
+//
+//.cc-btn.cc-dismiss {
+//  color: #fcfcfc;
+//}
+//
+//.cc-btn:hover {
+//  background-color: red;
+//}
+//
+////.cc-btn:hover {
+////  background-color: lighten($brand-secondary, 5%);
+////  color: #fcfcfc;
+////}
+
+// .cc-message {
+//   width: auto;
+//   background: white;
+//   padding: 20px 76px 20px 16px;
+//   border-radius: 10px;
+//   margin-right: -70px;
+//   margin-left: 20%;
+// }
+
+//.cc-link, .cc-link:visited {
+//  color: lighten(#fcfcfc, 5%);
+//}
+//
+//.cc-btn {
+//  background-color: $brand-secondary;
+//  border-color: lighten($brand-primary, 5%);
+//}
+//
+//.cc-btn:hover {
+//  background-color: lighten($brand-primary, 5%);
+//  border-color: $brand-primary;
+//}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -2,6 +2,7 @@ $fa-font-path: "../vendor/fontawesome/fonts";
 
 @import "../vendor/fontawesome/scss/font-awesome";
 @import "../vendor/academicons/css/academicons.css";
+@import "cookieconsent";
 @import "atmire-cua";
 @import "atmire-cua-customizations";
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure-alterations.xsl
@@ -21,6 +21,20 @@
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+            // Attempt to get status of cookieconsent cookie
+            var cookieConsentStatus = getCookie('cookieconsent_status');
+
+            // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+            initializeCookieConsent();
+
+            // If user has not explicitly allowed we should set a property to disable Google Analytics
+            // If user has explicitly allowed the value of the cookieconsent cookie will be "allow", if not it will be "dismiss"
+            // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+            if ( cookieConsentStatus != 'allow' ) {
+            window['ga-disable-</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>'] = true;
+            }
+
+            // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
             ga('create', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
             ga('send', 'pageview', {
               'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/core/page-structure.xsl
@@ -711,6 +711,7 @@
 
                             <i18n:text>xmlui.dri2xhtml.structural.about-link</i18n:text>
                         </a>
+                        <a href="https://www.ilri.org/privacy-cookies-statement" title="ILRI privacy statement" target="_blank" rel="noopener">Privacy Policy</a>
                         <a>
                             <xsl:attribute name="href">
                                 <xsl:value-of

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/styles/_style.scss
@@ -33,3 +33,8 @@ header .navbar-default {
 .trail-wrapper .breadcrumb > li + li::before {
   color: $ccafs-white;
 }
+
+// color of text on cookieconsent accept button
+.cc-btn.cc-allow, .cc-btn.cc-allow:hover {
+  color: $ccafs-black-text;
+}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/styles/_style.scss
@@ -33,3 +33,8 @@ header .navbar-default {
 .trail-wrapper .breadcrumb > li + li::before {
   color: $brand-primary;
 }
+
+// color of text on cookieconsent accept button
+.cc-btn.cc-allow, .cc-btn.cc-allow:hover {
+  color: $brand-primary;
+}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/styles/_style.scss
@@ -28,3 +28,8 @@ header .navbar-default {
 .trail-toggle .navbar-toggle .icon-bar {
   background-color: $brand-primary;
 }
+
+// color of text on cookieconsent accept button
+.cc-btn.cc-allow, .cc-btn.cc-allow:hover {
+  color: $brand-primary;
+}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/styles/_style.scss
@@ -36,3 +36,8 @@ header .navbar-default {
 .text-muted {
   color: #666;
 }
+
+// color of text on cookieconsent accept button
+.cc-btn.cc-allow, .cc-btn.cc-allow:hover {
+  color: $ilri-gray;
+}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
@@ -5,7 +5,8 @@
     "jquery-ui": "1.10.3",
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
-    "academicons": "1.8.0"
+    "academicons": "1.8.0",
+    "cookieconsent": "^3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/xsl/core/page-structure-alterations.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/xsl/core/page-structure-alterations.xsl
@@ -20,6 +20,19 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        // Attempt to get status of cookieconsent cookie
+        var cookieConsentStatus = getCookie('cookieconsent_status');
+
+        // Initialize cookieconsent popup (will only show popup if cookieconsent has not been dismissed with allow or disallow)
+        initializeCookieConsent();
+
+        // If user has not allowed, set property to disable Google Analytics
+        // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+        if ( cookieConsentStatus != 'allow' ) {
+        window['ga-disable-</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>'] = true;
+        }
+
+        // Initialize Google Analytics with IP anonymization (will not actually send any data to Google if ga-disable-XXXXX-Y property is set)
         ga('create', '</xsl:text><xsl:value-of select="$theme-google-analytics-id"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
         ga('send', 'pageview', {
           'anonymizeIp': true


### PR DESCRIPTION
Adds a popup using cookieconsent that asks the user to agree or disagree to the ILRI privacy policy. We do not enable Google Analytics until they give affirmative consent.