### PR TITLE
xmlui: Fix cookieconsent glitch

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/bower.json
@@ -15,7 +15,7 @@
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
     "datatables": "1.10.3",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AVCD/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AfricaRising/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/AgriFood/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Bioversity/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CCAFS/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CGIARSystem/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIAT/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIFOR/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CIP/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CPWF/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CRP3.7/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/CTA/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/DrylandSystems/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/EADD/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/FeedTheFuture/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Humidtropics/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ICARDA/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IITA/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ILRI/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/IWMI/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/LIVES/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Livestock/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/PABRA/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/RTB/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/TechnicalConsortium/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/WLE/bower.json
@@ -6,7 +6,7 @@
     "bootstrap-sass-official": "3.3.0",
     "fontawesome": "4.5.0",
     "academicons": "1.8.0",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "3.0.6"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
The cookieconsent plugin got updated without me realizing it and it seems that some of the styles changed. For now we should explicitly use version 3.0.6 because it works (aside from known issue about it not dismissing properly).