### PR TITLE
Disable logging of bot events in Solr

### DIFF
--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -25,4 +25,4 @@ authorization.admin.workflow=true
 # If true, event will be logged with the 'isBot' field set to true
 # (see query.filter.* for query filter options)
 # Default value is true.
-#logBots = true
+logBots = false


### PR DESCRIPTION
Over the last few years our Solr statistics core has grown to hold about 150 million documents, 60 million of which are from bots. This is about 40GB of worthless data on the disk and adds a large overhead to all Solr operations. I'm well aware that Google, Baidu, Yandex, and Bing are slamming our server constantly. What good does it do to log these events in Solr? Furthermore, I have purged all events from Solr where isBot:true. Good riddance.