### PR TITLE
xmlui: Constrain thumbnails to 200px in item lists

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -184,6 +184,10 @@ width:85%
   /* clickable area of thumbnails should not fill the entire area of the parent div */
   display: inline-block;
 }
+.artifact-preview a>img {
+  /* visually constrain very tall thumbnails in the item lists (but not item views) */
+  max-height: 200px;
+}
 .auto-open-statlets #aspect_statistics_StatletTransformer_div_showStats{
   display: none;
 }


### PR DESCRIPTION
Some items (like infographics) are very tall and their thumbnails take up an unreasonable amount of vertical space in item lists.