### PR TITLE
xmlui: Constrain tall thumbnails to 170px in item list

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/styles/_style.scss
@@ -186,7 +186,7 @@ width:85%
 }
 .artifact-preview a>img {
   /* visually constrain very tall thumbnails in the item lists (but not item views) */
-  max-height: 200px;
+  max-height: 170px;
 }
 .auto-open-statlets #aspect_statistics_StatletTransformer_div_showStats{
   display: none;


### PR DESCRIPTION
I had previously used 200px, but it didn't seem to be enough. Looking at other "normal" thumbnails I can see that they are using 128x167 so let's use something closer to that.