### PR TITLE
input-forms.xml: Improve usage rights

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -1565,28 +1565,56 @@
         <stored-value></stored-value>
       </pair>
       <pair>
-        <displayed-value>CC-BY</displayed-value>
-        <stored-value>CC-BY</stored-value>
+        <displayed-value>Creative Commons Attribution 4.0 (CC BY 4.0)</displayed-value>
+        <stored-value>CC-BY-4.0</stored-value>
       </pair>
       <pair>
-        <displayed-value>CC-BY-SA</displayed-value>
-        <stored-value>CC-BY-SA</stored-value>
+        <displayed-value>Creative Commons Attribution-ShareAlike 4.0 (CC BY-SA 4.0)</displayed-value>
+        <stored-value>CC-BY-SA-4.0</stored-value>
       </pair>
       <pair>
-        <displayed-value>CC-BY-ND</displayed-value>
-        <stored-value>CC-BY-ND</stored-value>
+        <displayed-value>Creative Commons Attribution-NoDerivatives 4.0 (CC BY-ND 4.0)</displayed-value>
+        <stored-value>CC-BY-ND-4.0</stored-value>
       </pair>
       <pair>
-        <displayed-value>CC-BY-NC</displayed-value>
-        <stored-value>CC-BY-NC</stored-value>
+        <displayed-value>Creative Commons Attribution-NonCommercial 4.0 (CC BY-NC 4.0)</displayed-value>
+        <stored-value>CC-BY-NC-4.0</stored-value>
       </pair>
       <pair>
-        <displayed-value>CC-BY-NC-SA</displayed-value>
-        <stored-value>CC-BY-NC-SA</stored-value>
+        <displayed-value>Creative Commons Attribution-NonCommercial-ShareAlike 4.0 (CC BY-NC-SA 4.0)</displayed-value>
+        <stored-value>CC-BY-NC-SA-4.0</stored-value>
       </pair>
       <pair>
-        <displayed-value>CC-BY-NC-ND</displayed-value>
-        <stored-value>CC-BY-NC-ND</stored-value>
+        <displayed-value>Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 (CC BY-NC-ND 4.0)</displayed-value>
+        <stored-value>CC-BY-NC-ND-4.0</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Creative Commons Attribution 3.0 (CC BY 3.0)</displayed-value>
+        <stored-value>CC-BY-3.0</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Creative Commons Attribution-ShareAlike 3.0 (CC BY-SA 3.0)</displayed-value>
+        <stored-value>CC-BY-SA-3.0</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Creative Commons Attribution-NoDerivs 3.0 (CC BY-ND 3.0)</displayed-value>
+        <stored-value>CC-BY-ND-3.0</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Creative Commons Attribution-NonCommercial 3.0 (CC BY-NC 3.0)</displayed-value>
+        <stored-value>CC-BY-NC-3.0</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Creative Commons Attribution-NonCommercial-ShareAlike 3.0 (CC BY-NC-SA 3.0)</displayed-value>
+        <stored-value>CC-BY-NC-SA-3.0</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Creative Commons Attribution-NonCommercial-NoDerivs 3.0 (CC BY-NC-ND 3.0)</displayed-value>
+        <stored-value>CC-BY-NC-ND-3.0</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Creative Commons Zero Public Domain Dedication 1.0 (CC0 1.0)</displayed-value>
+        <stored-value>CC0-1.0</stored-value>
       </pair>
       <pair>
         <displayed-value>Copyrighted; Any re-use allowed</displayed-value>


### PR DESCRIPTION
This adds the long names for each license and adds version 3.0 as well as the Creative Commons Zero public domain license. We still have some items being submitted with version 3.0 (and older!) of
the licenses, and CC0 is used for data sets. I am hoping that the long names will be useful to help people identify and match each license to the one in their publication or on a publisher's page.