### PR TITLE
Add in-house metadata workflow scripts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,19 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+colorama = "*"
+petl = "*"
+requests = "*"
+solrclient = {ref = "kazoo-2.5.0", git = "https://github.com/alanorth/SolrClient.git"}
+"psycopg2-binary" = "*"
+requests-cache = "*"
+csvkit = "*"
+
+[dev-packages]
+"flake8" = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,297 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e8ed260e056a66ad9916d4bd107c0b42e6d542f5670b44a899a9dd5b602faf56"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "agate": {
+            "hashes": [
+                "sha256:48d6f80b35611c1ba25a642cbc5b90fcbdeeb2a54711c4a8d062ee2809334d1c",
+                "sha256:c93aaa500b439d71e4a5cf088d0006d2ce2c76f1950960c8843114e5f361dfd3"
+            ],
+            "version": "==1.6.1"
+        },
+        "agate-dbf": {
+            "hashes": [
+                "sha256:0666c1ad06cd4b2860351cebbd88bd4b05b2d1abd41b25cf91f8f6715035735e",
+                "sha256:e445f17ebd0ab31cd0c2d086d79e95d9924deb251f733ea283161e3c8181333c"
+            ],
+            "version": "==0.2.0"
+        },
+        "agate-excel": {
+            "hashes": [
+                "sha256:8923f71ee2b5b7b21e52fb314a769b28fb902f647534f5cbbb41991d8710f4c7"
+            ],
+            "version": "==0.2.2"
+        },
+        "agate-sql": {
+            "hashes": [
+                "sha256:877b7b85adb5f0325455bba8d50a1623fa32af33680b554feca7c756a15ad9b4"
+            ],
+            "version": "==0.5.3"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
+                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
+            ],
+            "version": "==2.6.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "index": "pypi",
+            "version": "==0.4.1"
+        },
+        "csvkit": {
+            "hashes": [
+                "sha256:a6c859c1321d4697dc41252877249091681297f093e08d9c1e1828a6d52c260c"
+            ],
+            "index": "pypi",
+            "version": "==1.0.3"
+        },
+        "dbfread": {
+            "hashes": [
+                "sha256:07c8a9af06ffad3f6f03e8fe91ad7d2733e31a26d2b72c4dd4cfbae07ee3b73d",
+                "sha256:f604def58c59694fa0160d7be5d0b8d594467278d2bb6a47d46daf7162c84cec"
+            ],
+            "version": "==2.0.7"
+        },
+        "et-xmlfile": {
+            "hashes": [
+                "sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b"
+            ],
+            "version": "==1.0.1"
+        },
+        "future": {
+            "hashes": [
+                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+            ],
+            "version": "==0.17.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
+        },
+        "jdcal": {
+            "hashes": [
+                "sha256:948fb8d079e63b4be7a69dd5f0cd618a0a57e80753de8248fd786a8a20658a07",
+                "sha256:ea0a5067c5f0f50ad4c7bdc80abad3d976604f6fb026b0b3a17a9d84bb9046c9"
+            ],
+            "version": "==1.4"
+        },
+        "leather": {
+            "hashes": [
+                "sha256:076d1603b5281488285718ce1a5ce78cf1027fe1e76adf9c548caf83c519b988",
+                "sha256:e0bb36a6d5f59fbf3c1a6e75e7c8bee29e67f06f5b48c0134407dde612eba5e2"
+            ],
+            "version": "==0.3.3"
+        },
+        "openpyxl": {
+            "hashes": [
+                "sha256:70da6b45a5925285b6a3d93570b45f4402eb2d335740163a58eef533b139565c"
+            ],
+            "version": "==2.6.0"
+        },
+        "parsedatetime": {
+            "hashes": [
+                "sha256:3d817c58fb9570d1eec1dd46fa9448cd644eeed4fb612684b02dfda3a79cb84b",
+                "sha256:9ee3529454bf35c40a77115f5a596771e59e1aee8c53306f346c461b8e913094"
+            ],
+            "version": "==2.4"
+        },
+        "petl": {
+            "hashes": [
+                "sha256:9f10da5719d731844ccc278f6dfc092e17eb93197d92c556a9d5903202226863"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0"
+        },
+        "psycopg2-binary": {
+            "hashes": [
+                "sha256:19a2d1f3567b30f6c2bb3baea23f74f69d51f0c06c2e2082d0d9c28b0733a4c2",
+                "sha256:2b69cf4b0fa2716fd977aa4e1fd39af6110eb47b2bb30b4e5a469d8fbecfc102",
+                "sha256:2e952fa17ba48cbc2dc063ddeec37d7dc4ea0ef7db0ac1eda8906365a8543f31",
+                "sha256:348b49dd737ff74cfb5e663e18cb069b44c64f77ec0523b5794efafbfa7df0b8",
+                "sha256:3d72a5fdc5f00ca85160915eb9a973cf9a0ab8148f6eda40708bf672c55ac1d1",
+                "sha256:4957452f7868f43f32c090dadb4188e9c74a4687323c87a882e943c2bd4780c3",
+                "sha256:5138cec2ee1e53a671e11cc519505eb08aaaaf390c508f25b09605763d48de4b",
+                "sha256:587098ca4fc46c95736459d171102336af12f0d415b3b865972a79c03f06259f",
+                "sha256:5b79368bcdb1da4a05f931b62760bea0955ee2c81531d8e84625df2defd3f709",
+                "sha256:5cf43807392247d9bc99737160da32d3fa619e0bfd85ba24d1c78db205f472a4",
+                "sha256:676d1a80b1eebc0cacae8dd09b2fde24213173bf65650d22b038c5ed4039f392",
+                "sha256:6b0211ecda389101a7d1d3df2eba0cf7ffbdd2480ca6f1d2257c7bd739e84110",
+                "sha256:79cde4660de6f0bb523c229763bd8ad9a93ac6760b72c369cf1213955c430934",
+                "sha256:7aba9786ac32c2a6d5fb446002ed936b47d5e1f10c466ef7e48f66eb9f9ebe3b",
+                "sha256:7c8159352244e11bdd422226aa17651110b600d175220c451a9acf795e7414e0",
+                "sha256:945f2eedf4fc6b2432697eb90bb98cc467de5147869e57405bfc31fa0b824741",
+                "sha256:96b4e902cde37a7fc6ab306b3ac089a3949e6ce3d824eeca5b19dc0bedb9f6e2",
+                "sha256:9a7bccb1212e63f309eb9fab47b6eaef796f59850f169a25695b248ca1bf681b",
+                "sha256:a3bfcac727538ec11af304b5eccadbac952d4cca1a551a29b8fe554e3ad535dc",
+                "sha256:b19e9f1b85c5d6136f5a0549abdc55dcbd63aba18b4f10d0d063eb65ef2c68b4",
+                "sha256:b664011bb14ca1f2287c17185e222f2098f7b4c857961dbcf9badb28786dbbf4",
+                "sha256:bde7959ef012b628868d69c474ec4920252656d0800835ed999ba5e4f57e3e2e",
+                "sha256:cb095a0657d792c8de9f7c9a0452385a309dfb1bbbb3357d6b1e216353ade6ca",
+                "sha256:d16d42a1b9772152c1fe606f679b2316551f7e1a1ce273e7f808e82a136cdb3d",
+                "sha256:d444b1545430ffc1e7a24ce5a9be122ccd3b135a7b7e695c5862c5aff0b11159",
+                "sha256:d93ccc7bf409ec0a23f2ac70977507e0b8a8d8c54e5ee46109af2f0ec9e411f3",
+                "sha256:df6444f952ca849016902662e1a47abf4fa0678d75f92fd9dd27f20525f809cd",
+                "sha256:e63850d8c52ba2b502662bf3c02603175c2397a9acc756090e444ce49508d41e",
+                "sha256:ec43358c105794bc2b6fd34c68d27f92bea7102393c01889e93f4b6a70975728",
+                "sha256:f4c6926d9c03dadce7a3b378b40d2fea912c1344ef9b29869f984fb3d2a2420b"
+            ],
+            "index": "pypi",
+            "version": "==2.7.7"
+        },
+        "python-slugify": {
+            "hashes": [
+                "sha256:d3e034397236020498e677a35e5c05dcc6ba1624b608b9ef7e5fe3090ccbd5a8"
+            ],
+            "version": "==2.0.1"
+        },
+        "pytimeparse": {
+            "hashes": [
+                "sha256:04b7be6cc8bd9f5647a6325444926c3ac34ee6bc7e69da4367ba282f076036bd",
+                "sha256:e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a"
+            ],
+            "version": "==1.1.8"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+            ],
+            "version": "==2018.9"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "requests-cache": {
+            "hashes": [
+                "sha256:e9270030becc739b0a7f7f834234c73a878b2d794122bf76f40055a22419eb67",
+                "sha256:fe561ca119879bbcfb51f03a35e35b425e18f338248e59fd5cf2166c77f457a2"
+            ],
+            "index": "pypi",
+            "version": "==0.4.13"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "solrclient": {
+            "git": "https://github.com/alanorth/SolrClient.git",
+            "ref": "c629e3475be37c82770b2be61748be7e29882648"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:52a42dbf02d0562d6e90e7af59f177f1cc027e72833cc29c3a821eefa009c71d"
+            ],
+            "version": "==1.2.17"
+        },
+        "unidecode": {
+            "hashes": [
+                "sha256:092cdf7ad9d1052c50313426a625b717dab52f7ac58f859e09ea020953b1ad8f",
+                "sha256:8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb"
+            ],
+            "version": "==1.0.23"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        },
+        "xlrd": {
+            "hashes": [
+                "sha256:546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2",
+                "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"
+            ],
+            "version": "==1.2.0"
+        }
+    },
+    "develop": {
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:c3ba1e130c813191db95c431a18cb4d20a468e98af7a77e2181b68574481ad36",
+                "sha256:fd9ddf503110bf3d8b1d270e8c673aab29ccb3dd6abf29bae1f54e5116ab4a91"
+            ],
+            "index": "pypi",
+            "version": "==3.7.5"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d",
+                "sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"
+            ],
+            "version": "==2.1.0"
+        }
+    }
+}

--- a/add-dc-rights.py
+++ b/add-dc-rights.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+#
+# add-dc-rights.py 1.1.1
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+#
+# Add usage rights (dc.rights) to items from CSV.
+#
+# This script searches for items by handle and adds a dc.rights field to each
+# (assuming one does not exist). The format of the CSV file should be:
+#
+# dc.rights,handle
+# CC-BY-NC-ND,10568/72643
+# CC-BY-NC-ND,10568/72644
+#
+# This script is written for Python 3 and requires several modules that you can
+# install with pip (for example, in a virtual environment):
+#
+#   $ pip install colorama psycopg2-binary
+#
+
+import argparse
+import csv
+from colorama import Fore
+import psycopg2
+import signal
+import sys
+
+
+def main():
+    # parse the command line arguments
+    parser = argparse.ArgumentParser(description='Add usage rights to items from CSV.')
+    parser.add_argument('--csv-file', '-i', help='CSV file containing item handles and rights.', required=True, type=argparse.FileType('r', encoding='UTF-8'))
+    parser.add_argument('--database-name', "-db", help='Database name', required=True)
+    parser.add_argument('--database-user', "-u", help='Database username', required=True)
+    parser.add_argument('--database-pass', "-p", help='Database password', required=True)
+    parser.add_argument('--debug', '-d', help='Print debug messages to standard error (stderr).', action='store_true')
+    parser.add_argument('--dry-run', '-n', help='Only print changes that would be made.', action='store_true')
+    parser.add_argument('--handle-field-name', '-hf', help='Name of column with handles in "10568/4" format (no URL).', default='handle')
+    parser.add_argument('--rights-field-name', '-rf', help='Name of column with usage rights.', default='dc.rights')
+    args = parser.parse_args()
+
+    # set the signal handler for SIGINT (^C) so we can exit cleanly
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # connect to database
+    try:
+        conn_string = 'dbname={database_name} user={database_user} password={database_pass} host=localhost'.format(database_name=args.database_name, database_user=args.database_user, database_pass=args.database_pass)
+        conn = psycopg2.connect(conn_string)
+
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Connected to the database.\n' + Fore.RESET)
+    except psycopg2.OperationalError:
+        sys.stderr.write(Fore.RED + 'Unable to connect to the database.\n' + Fore.RESET)
+
+        # close output file before we exit
+        args.csv_file.close()
+
+        exit(1)
+
+    # open the CSV
+    reader = csv.DictReader(args.csv_file)
+
+    # iterate over rows in the CSV
+    for row in reader:
+        handle = row[args.handle_field_name]
+        rights = row[args.rights_field_name]
+
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Finding item with handle {handle}\n'.format(handle=handle) + Fore.RESET)
+
+        with conn:
+            # cursor will be closed after this block exits
+            # see: http://initd.org/psycopg/docs/usage.html#with-statement
+            with conn.cursor() as cursor:
+                # get resource_id for current handle
+                sql = 'SELECT resource_id FROM handle WHERE handle=%s'
+                # remember that tuples with one item need a comma after them!
+                cursor.execute(sql, (handle,))
+
+                # no resource_id with this handle exists
+                if cursor.rowcount == 0:
+                    if args.debug:
+                        sys.stderr.write(Fore.YELLOW + 'Did not find item with handle {handle}, skipping.\n'.format(handle=handle) + Fore.RESET)
+
+                    continue
+
+                # multiple resource_id with this handle exist (I don't think this will happen, but better to check)
+                elif cursor.rowcount > 1:
+                    if args.debug:
+                        sys.stderr.write(Fore.YELLOW + 'Found multiple items with handle {handle}, skipping.\n'.format(handle=handle) + Fore.RESET)
+
+                    continue
+
+                result = cursor.fetchone()
+                # result will be an array like: [74525]
+                resource_id = result[0]
+
+                # in our test environment I've seen resource_id be NULL for some reason
+                if resource_id is None:
+                    if args.debug:
+                        sys.stderr.write(Fore.YELLOW + 'Item with handle {handle} does not have a resource_id, skipping.\n'.format(handle=handle) + Fore.RESET)
+
+                    continue
+
+                # Check if this item already has dc.rights metadata
+                # resource_type_id 2 is for item metadata, metadata_field_id 53 is dc.rights
+                sql = 'SELECT text_value FROM metadatavalue WHERE resource_type_id=2 AND resource_id=%s AND metadata_field_id=53'
+                # remember that tuples with one item need a comma after them!
+                cursor.execute(sql, (resource_id, ))
+
+                # if rowcount is greater than 0 there must be existing rights for this item
+                if cursor.rowcount > 0:
+                    if args.debug:
+                        sys.stderr.write(Fore.YELLOW + 'Found existing rights metadata for item with handle {handle}, skipping.\n'.format(handle=handle) + Fore.RESET)
+                    continue
+
+                # no existing rights metadata, so add one
+                result = cursor.fetchone()
+
+                if args.dry_run:
+                    print(Fore.GREEN + 'Would add rights "{rights}" to item with handle {handle}.\n'.format(rights=rights, handle=handle) + Fore.RESET)
+                    continue
+
+                if args.debug:
+                    sys.stderr.write(Fore.GREEN + 'Adding rights "{rights}" to item with handle {handle}.\n'.format(rights=rights, handle=handle) + Fore.RESET)
+
+                # metadatavalue IDs come from a PostgreSQL sequence that increments when you call it
+                cursor.execute("SELECT nextval('metadatavalue_seq')")
+                metadata_value_id = cursor.fetchone()[0]
+
+                # resource_type_id 2 is for item metadata, metadata_field_id 53 is dc.rights
+                sql = 'INSERT INTO metadatavalue (metadata_value_id, resource_id, metadata_field_id, text_value, place, confidence, resource_type_id) VALUES (%s, %s, %s, %s, %s, %s, %s)'
+                cursor.execute(sql, (metadata_value_id, resource_id, 53, rights, 1, -1, 2))
+
+    if args.debug:
+        sys.stderr.write(Fore.GREEN + 'Disconnecting from database.\n' + Fore.RESET)
+
+    # close the database connection before leaving
+    conn.close()
+
+    # close output file before we exit
+    args.csv_file.close()
+
+
+def signal_handler(signal, frame):
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/add-orcid-identifiers-csv.py
+++ b/add-orcid-identifiers-csv.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+#
+# add-orcid-identifiers-csv.py 1.0.0
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+#
+# Add ORCID identifiers to items for a given author name from CSV.
+#
+# We had previously migrated the ORCID identifiers from CGSpace's authority Solr
+# core to cg.creator.id fields in matching items, but now we want to add them to
+# other matching items in a more arbitrary fashion. Items that are older or were
+# uploaded in batch did not have matching authors in the authority core, so they
+# did not benefit from that migration, for example.
+#
+# This script searches for items by author name and adds a cg.creator.id field
+# to each (assuming one does not exist). The format of the CSV file should be:
+#
+# dc.contributor.author,cg.creator.id
+# "Orth, Alan",Alan S. Orth: 0000-0002-1735-7458
+# "Orth, A.",Alan S. Orth: 0000-0002-1735-7458
+#
+# The order of authors in dc.contributor.author is respected and mirrored in the
+# new cg.creator.id fields.
+#
+# This script is written for Python 3 and requires several modules that you can
+# install with pip (I recommend setting up a Python virtual environment first):
+#
+#   $ pip install colorama psycopg2-binary
+#
+
+import argparse
+from colorama import Fore
+import csv
+import psycopg2
+import re
+import signal
+import sys
+
+
+def main():
+    # parse the command line arguments
+    parser = argparse.ArgumentParser(description='Add ORCID identifiers to items for a given author name from CSV. Respects the author order from the dc.contributor.author field.')
+    parser.add_argument('--author-field-name', '-f', help='Name of column with author names.', default='dc.contributor.author')
+    parser.add_argument('--csv-file', '-i', help='CSV file containing author names and ORCID identifiers.', required=True, type=argparse.FileType('r', encoding='UTF-8'))
+    parser.add_argument("--database-name", "-db", help='Database name', required=True)
+    parser.add_argument("--database-user", "-u", help='Database username', required=True)
+    parser.add_argument("--database-pass", "-p", help='Database password', required=True)
+    parser.add_argument('--debug', '-d', help='Print debug messages to standard error (stderr).', action='store_true')
+    parser.add_argument('--dry-run', '-n', help='Only print changes that would be made.', action='store_true')
+    parser.add_argument('--orcid-field-name', '-o', help='Name of column with creators in "Name: 0000-0000-0000-0000" format.', default='cg.creator.id')
+    args = parser.parse_args()
+
+    # set the signal handler for SIGINT (^C) so we can exit cleanly
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # connect to database
+    try:
+        conn_string = 'dbname={0} user={1} password={2} host=localhost'.format(args.database_name, args.database_user, args.database_pass)
+        conn = psycopg2.connect(conn_string)
+
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Connected to the database.\n' + Fore.RESET)
+    except psycopg2.OperationalError:
+        sys.stderr.write(Fore.RED + 'Unable to connect to the database.\n' + Fore.RESET)
+
+        # close output file before we exit
+        args.csv_file.close()
+
+        exit(1)
+
+    # open the CSV
+    reader = csv.DictReader(args.csv_file)
+
+    # iterate over rows in the CSV
+    for row in reader:
+        author_name = row[args.author_field_name]
+
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Finding items with author name: {0}\n'.format(author_name) + Fore.RESET)
+
+        with conn:
+            # cursor will be closed after this block exits
+            # see: http://initd.org/psycopg/docs/usage.html#with-statement
+            with conn.cursor() as cursor:
+                # find all item metadata records with this author name
+                # resource_type_id 2 is item metadata, metadata_field_id 3 is author
+                sql = 'SELECT resource_id, place FROM metadatavalue WHERE resource_type_id=2 AND metadata_field_id=3 AND text_value=%s'
+                # remember that tuples with one item need a comma after them!
+                cursor.execute(sql, (author_name,))
+                records_with_author_name = cursor.fetchall()
+
+                if len(records_with_author_name) >= 0:
+                    if args.debug:
+                        sys.stderr.write(Fore.GREEN + 'Found {0} items.\n'.format(len(records_with_author_name)) + Fore.RESET)
+
+                    # extract cg.creator.id text to add from CSV and strip leading/trailing whitespace
+                    text_value = row[args.orcid_field_name].strip()
+                    # extract the ORCID identifier from the cg.creator.id text field in the CSV
+                    orcid_identifier_pattern = re.compile('[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}')
+                    orcid_identifier_match = orcid_identifier_pattern.search(text_value)
+
+                    # sanity check to make sure we extracted the ORCID identifier from the cg.creator.id text in the CSV
+                    if orcid_identifier_match is None:
+                        if args.debug:
+                            sys.stderr.write(Fore.YELLOW + 'Skipping invalid ORCID identifier in "{0}".\n'.format(text_value) + Fore.RESET)
+                        continue
+
+                    # we only expect one ORCID identifier, so if it matches it will be group "0"
+                    # see: https://docs.python.org/3/library/re.html
+                    orcid_identifier = orcid_identifier_match.group(0)
+
+                    # iterate over results for current author name to add cg.creator.id metadata
+                    for record in records_with_author_name:
+                        resource_id = record[0]
+                        # "place" is the order of a metadata value so we can add the cg.creator.id metadata matching the author order
+                        place = record[1]
+                        confidence = -1
+
+                        # get the metadata_field_id for the cg.creator.id field
+                        sql = "SELECT metadata_field_id FROM metadatafieldregistry WHERE metadata_schema_id=2 AND element='creator' AND qualifier='id'"
+                        cursor.execute(sql)
+                        metadata_field_id = cursor.fetchall()[0]
+
+                        # check if there is an existing cg.creator.id with this author's ORCID identifier for this item (without restricting the "place")
+                        # note that the SQL here is quoted differently to allow us to use LIKE with % wildcards with our paremeter subsitution
+                        # resource_type_id 2 is item metadata
+                        sql = "SELECT * from metadatavalue WHERE resource_id=%s AND metadata_field_id=%s AND text_value LIKE '%%' || %s || '%%' AND confidence=%s AND resource_type_id=2"
+
+                        cursor.execute(sql, (resource_id, metadata_field_id, orcid_identifier, confidence))
+                        records_with_orcid_identifier = cursor.fetchall()
+
+                        if len(records_with_orcid_identifier) == 0:
+                            if args.dry_run:
+                                print('Would add ORCID identifier "{0}" to item {1}.'.format(text_value, resource_id))
+                                continue
+
+                            print('Adding ORCID identifier "{0}" to item {1}.'.format(text_value, resource_id))
+
+                            # metadatavalue IDs come from a PostgreSQL sequence that increments when you call it
+                            cursor.execute("SELECT nextval('metadatavalue_seq')")
+                            metadata_value_id = cursor.fetchone()[0]
+
+                            sql = 'INSERT INTO metadatavalue (metadata_value_id, resource_id, metadata_field_id, text_value, place, confidence, resource_type_id) VALUES (%s, %s, %s, %s, %s, %s, %s)'
+                            cursor.execute(sql, (metadata_value_id, resource_id, metadata_field_id, text_value, place, confidence, 2))
+                        else:
+                            if args.debug:
+                                sys.stderr.write(Fore.GREEN + 'Item {0} already has an ORCID identifier for {1}.\n'.format(resource_id, text_value) + Fore.RESET)
+
+    if args.debug:
+        sys.stderr.write(Fore.GREEN + 'Disconnecting from database.\n' + Fore.RESET)
+
+    # close the database connection before leaving
+    conn.close()
+
+    # close output file before we exit
+    args.csv_file.close()
+
+
+def signal_handler(signal, frame):
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/delete-metadata-values.py
+++ b/delete-metadata-values.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# delete-metadata-values.py 1.0.0
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+#
+# Expects a CSV with one column of metadata values to delete, for example:
+#
+# delete
+# "some value to delete"
+#
+#   $ ./delete-metadata-values.py -db database -u user -p password -m 3 -f delete -i file.csv
+#
+# This script is written for Python 3 and requires several modules that you can
+# install with pip (I recommend setting up a Python virtual environment first):
+#
+#   $ pip install psycopg2-binary
+#
+
+import argparse
+import csv
+import psycopg2
+import signal
+import sys
+
+
+def signal_handler(signal, frame):
+    sys.exit(0)
+
+
+parser = argparse.ArgumentParser(description='Delete metadata values in the DSpace SQL database.')
+parser.add_argument('--csv-file', '-i', help='Path to CSV file', type=argparse.FileType('r', encoding='UTF-8'))
+parser.add_argument('--database-name', '-db', help='Database name', required=True)
+parser.add_argument('--database-user', '-u', help='Database username', required=True)
+parser.add_argument('--database-pass', '-p', help='Database password', required=True)
+parser.add_argument('--debug', '-d', help='Print debug messages to standard error (stderr).', action='store_true')
+parser.add_argument('--dry-run', '-n', help='Only print changes that would be made.', action='store_true')
+parser.add_argument('--from-field-name', '-f', help='Name of column with values to be deleted', required=True)
+parser.add_argument('--metadata-field-id', '-m', type=int, help='ID of the field in the metadatafieldregistry table', required=True)
+parser.add_argument('--quiet', '-q', help='Do not print progress messages to the screen.', action='store_true')
+args = parser.parse_args()
+
+# open the CSV
+reader = csv.DictReader(args.csv_file)
+
+# set the signal handler for SIGINT (^C)
+signal.signal(signal.SIGINT, signal_handler)
+
+# connect to database
+try:
+    conn = psycopg2.connect("dbname={} user={} password={} host='localhost'".format(args.database_name, args.database_user, args.database_pass))
+
+    if args.debug:
+        sys.stderr.write('Connected to database.\n')
+except psycopg2.OperationalError:
+    sys.stderr.write('Could not connect to database.\n')
+    sys.exit(1)
+
+for row in reader:
+    with conn:
+        # cursor will be closed after this block exits
+        # see: http://initd.org/psycopg/docs/usage.html#with-statement
+        with conn.cursor() as cursor:
+            if args.dry_run:
+                # resource_type_id 2 is metadata for items
+                sql = 'SELECT text_value FROM metadatavalue WHERE resource_type_id=2 AND metadata_field_id=%s AND text_value=%s'
+                cursor.execute(sql, (args.metadata_field_id, row[args.from_field_name]))
+
+                if cursor.rowcount > 0 and not args.quiet:
+                    print('Would delete {0} occurences of: {1}'.format(cursor.rowcount, row[args.from_field_name]))
+
+            else:
+                sql = 'DELETE from metadatavalue WHERE resource_type_id=2 AND metadata_field_id=%s AND text_value=%s'
+                cursor.execute(sql, (args.metadata_field_id, row[args.from_field_name]))
+
+                if cursor.rowcount > 0 and not args.quiet:
+                    print('Deleted {0} occurences of: {1}'.format(cursor.rowcount, row[args.from_field_name]))
+
+# close database connection before we exit
+conn.close()
+
+# close the input file
+args.csv_file.close()
+
+sys.exit(0)

--- a/fix-metadata-values.py
+++ b/fix-metadata-values.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+# fix-metadata-values.py 1.0.0
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+#
+# Expects a CSV with two columns: one with "bad" metadata values and one with
+# correct values. Basically just a mass search and replace function for DSpace's
+# PostgreSQL database. Make sure to do a full `index-discovery -b` afterwards.
+#
+# This script is written for Python 3 and requires several modules that you can
+# install with pip (I recommend setting up a Python virtual environment first):
+#
+#   $ pip install psycopg2-binary
+#
+# See: http://initd.org/psycopg
+# See: http://initd.org/psycopg/docs/usage.html#with-statement
+# See: http://initd.org/psycopg/docs/faq.html#best-practices
+
+import argparse
+import csv
+import psycopg2
+import signal
+import sys
+
+
+def signal_handler(signal, frame):
+    sys.exit(1)
+
+
+parser = argparse.ArgumentParser(description='Find and replace metadata values in the DSpace SQL database.')
+parser.add_argument('--csv-file', '-i', help='Path to CSV file', required=True, type=argparse.FileType('r', encoding='UTF-8'))
+parser.add_argument('--database-name', '-db', help='Database name', required=True)
+parser.add_argument('--database-user', '-u', help='Database username', required=True)
+parser.add_argument('--database-pass', '-p', help='Database password', required=True)
+parser.add_argument('--debug', '-d', help='Print debug messages to standard error (stderr).', action='store_true')
+parser.add_argument('--dry-run', '-n', help='Only print changes that would be made.', action='store_true')
+parser.add_argument('--from-field-name', '-f', help='Name of column with values to be replaced.', required=True)
+parser.add_argument('--metadata-field-id', '-m', type=int, help='ID of the field in the metadatafieldregistry table.', required=True)
+parser.add_argument('--quiet', '-q', help='Do not print progress messages to the screen.', action='store_true')
+parser.add_argument('--to-field-name', '-t', help='Name of column with values to replace.', required=True)
+args = parser.parse_args()
+
+# open the CSV
+reader = csv.DictReader(args.csv_file)
+
+# set the signal handler for SIGINT (^C)
+signal.signal(signal.SIGINT, signal_handler)
+
+# connect to database
+try:
+    conn = psycopg2.connect("dbname={} user={} password={} host='localhost'".format(args.database_name, args.database_user, args.database_pass))
+
+    if args.debug:
+        sys.stderr.write('Connected to database.\n')
+except psycopg2.OperationalError:
+    sys.stderr.write('Could not connect to database.\n')
+    sys.exit(1)
+
+for row in reader:
+    if row[args.from_field_name] == row[args.to_field_name] and args.debug:
+        # sometimes editors send me corrections with identical search/replace patterns
+        sys.stderr.write('Skipping identical search and replace for value: {0}\n'.format(row[args.from_field_name]))
+        continue
+
+    with conn:
+        # cursor will be closed after this block exits
+        # see: http://initd.org/psycopg/docs/usage.html#with-statement
+        with conn.cursor() as cursor:
+            if args.dry_run:
+                # resource_type_id 2 is metadata for items
+                sql = 'SELECT text_value FROM metadatavalue WHERE resource_type_id=2 AND metadata_field_id=%s AND text_value=%s'
+                cursor.execute(sql, (args.metadata_field_id, row[args.from_field_name]))
+
+                if cursor.rowcount > 0 and not args.quiet:
+                    print('Would fix {0} occurences of: {1}'.format(cursor.rowcount, row[args.from_field_name]))
+            else:
+                sql = 'UPDATE metadatavalue SET text_value=%s WHERE resource_type_id=2 AND metadata_field_id=%s AND text_value=%s'
+                cursor.execute(sql, (row[args.to_field_name], args.metadata_field_id, row[args.from_field_name]))
+
+                if cursor.rowcount > 0 and not args.quiet:
+                    print('Fixed {0} occurences of: {1}'.format(cursor.rowcount, row[args.from_field_name]))
+
+# close database connection before we exit
+conn.close()
+
+# close input file
+args.csv_file.close()
+
+sys.exit(0)

--- a/generate-thumbnails.py
+++ b/generate-thumbnails.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# generate-thumbnails.py 1.0.0
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+
+# Reads the "filename" and "dc.identifier.url" fields from a CSV,
+# fetches the PDF, and generates a thumbnail using GraphicsMagick.
+#
+# The script is written for Python 3+ and requires PETL and Requests:
+#
+#   $ pip install petl requests
+#
+# See: https://petl.readthedocs.org/en/latest
+# See: https://requests.readthedocs.org/en/master
+
+import os.path
+import petl as etl
+import re
+import requests
+import signal
+import subprocess
+import sys
+
+
+def signal_handler(signal, frame):
+    sys.exit(0)
+
+
+# Process thumbnails from filename.pdf to filename.jpg using GraphicsMagick
+# and Ghostscript. Equivalent to the following shell invocation:
+#
+#   gm convert -quality 85 -thumbnail x400 -flatten 64661.pdf\[0\] cover.jpg
+#
+def create_thumbnail(record):
+
+    filename = record[0]
+    thumbnail = os.path.splitext(filename)[0] + '.jpg'
+    # check if we already have a thumbnail
+    if os.path.isfile(thumbnail):
+        print("> Thumbnail for", filename, "already exists")
+    else:
+        print("> Creating thumbnail for", filename)
+        subprocess.run(["gm", "convert", "-quality", "85", "-thumbnail", "x400", "-flatten", filename + "[0]", thumbnail])
+
+    return
+
+
+def download_bitstream(record):
+
+    # some records have multiple URLs separated by "||"
+    pattern = re.compile("\|\|")
+    urls = pattern.split(record[0])
+    filenames = pattern.split(record[1])
+    for url, filename in zip(urls, filenames):
+        print("URL: " + url)
+        print("File: " + filename)
+
+        # check if file exists
+        if os.path.isfile(filename):
+            print(">", filename, "already downloaded")
+        else:
+            print("> Downloading", filename)
+
+            response = requests.get(url, stream=True)
+            if response.status_code == 200:
+                with open(filename, 'wb') as fd:
+                    for chunk in response:
+                        fd.write(chunk)
+            else:
+                print("> Download failed, I'll try again next time")
+
+    return
+
+
+# make sure the user passed us the name of a CSV on the command line
+if len(sys.argv) == 2:
+    # read records from the CSV
+    records = etl.fromcsv(sys.argv[1])
+else:
+    print("Usage: " + sys.argv[0] + " filename.csv")
+    exit()
+
+# set the signal handler for SIGINT (^C)
+signal.signal(signal.SIGINT, signal_handler)
+
+# get URL and filename fields for each record
+# make sure other URL fields like dc.identifier.url[] etc are merged into this one and filename column exists!
+for record in etl.values(records, 'dc.identifier.url', 'filename'):
+    download_bitstream(record)
+
+    # maybe only generate thumbnails if -t is passed?
+    #create_thumbnail(record)

--- a/migrate-fields.sh
+++ b/migrate-fields.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Moves DSpace metadatavalues from one field to another. Assumed to be running
+# as the `postgres` Linux user. You MUST perform a full Discovery reindex after
+# doing this, ie: index-discovery -bf
+#
+# Alan Orth, April, 2016
+
+# Exit on first error
+set -o errexit
+
+# IDs of fields to move, in this format:
+#
+# old_field new_field
+#
+# fields are separated with tabs or spaces. Uses bash's `mapfile` to read into
+# an array.
+mapfile -t fields_to_move <<TO_MOVE
+72  55  #dc.source
+86  230 #cg.contributor.crp
+91  211 #cg.contributor.affiliation
+94  212 #cg.species
+107 231 #cg.coverage.subregion
+126 3   #dc.contributor.author
+73  219 #cg.identifier.url
+74  220 #cg.identifier.doi
+79  222 #cg.identifier.googleurl
+89  223 #cg.identifier.dataurl
+TO_MOVE
+
+# psql stuff
+readonly DATABASE_NAME=dspacetest
+readonly PSQL_BIN="/usr/bin/env psql"
+# clean startup, and only print results
+readonly PSQL_OPTS="--no-psqlrc --tuples-only --dbname $DATABASE_NAME"
+
+migrate_field() {
+    local old_id=$1
+    local new_id=$2
+    local psql_cmd="UPDATE metadatavalue SET metadata_field_id=${new_id} WHERE metadata_field_id=${old_id}"
+
+    $PSQL_BIN $PSQL_OPTS --echo-queries --command "$psql_cmd" \
+        && return 0 \
+        || return 1
+}
+
+main() {
+    local row
+
+    for row in "${fields_to_move[@]}"
+    do
+        # make sure row isn't a comment
+        if [[ $row =~ ^[[:space:]]?# ]]; then
+            continue
+        fi
+
+        # call migrate_field() with format:
+        # migrate_field 66 109
+        migrate_field $row
+
+        # relax!
+        sleep 1
+    done
+}
+
+main
+
+# vim: set expandtab:ts=4:sw=4:bs=2

--- a/move-collections.sh
+++ b/move-collections.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Moves DSpace collections from one community to another. Takes a list of
+# handles, then resolves their internal resource_id's and reassigns the
+# community relationship. Assumed to be running as `postgres` Linux user.
+#
+# I don't think reindexing is required, because no metadata has changed,
+# and therefore no search or browse indexes need to be updated.
+#
+# Alan Orth, January, 2016
+
+# Exit on first error
+set -o errexit
+
+# Read handles to move into an array
+# format:
+#
+# collection from_community to_community
+#
+# Handles are separated with tabs or spaces. Uses `mapfile` to read into
+# an array.
+mapfile -t items_to_move <<TO_MOVE
+10568/51821 10568/42212 10568/42211
+10568/51400 10568/42214 10568/42211
+10568/56992 10568/42216 10568/42211
+10568/42218 10568/42217 10568/42211
+TO_MOVE
+
+# psql stuff
+readonly DATABASE_NAME=dspacetest
+readonly PSQL_BIN='/usr/bin/env psql'
+# clean startup, and only print results
+readonly PSQL_OPTS="--no-psqlrc --tuples-only --dbname $DATABASE_NAME"
+
+# Get an internal resource id for a handle (community / collection)
+get_resource_id() {
+    local handle=$1
+    local psql_cmd="SELECT resource_id FROM handle WHERE handle = '$handle'"
+
+    $PSQL_BIN $PSQL_OPTS --command "$psql_cmd" | sed -e '/^$/d' -e 's/^[ \t]*//' \
+        && return 0 \
+        || return 1
+}
+
+move_collection() {
+    local collection_id=$(get_resource_id $1)
+    local old_community_id=$(get_resource_id $2)
+    local new_community_id=$(get_resource_id $3)
+    local psql_cmd="UPDATE community2collection SET community_id=$new_community_id WHERE community_id=$old_community_id and collection_id=$collection_id"
+
+    if [[ -z $collection_id || -z $old_community_id || -z $new_community_id ]]; then
+        echo "Problem moving collection $1. Please make sure the to and from communities are correct."
+        return 1
+    fi
+
+    $PSQL_BIN $PSQL_OPTS --echo-queries --command "$psql_cmd" \
+        && return 0 \
+        || return 1
+}
+
+main() {
+    local row
+
+    for row in "${items_to_move[@]}"
+    do
+        # make sure row isn't a comment
+        if [[ $row =~ ^[[:space:]]?# ]]; then
+            continue
+        fi
+
+        # call move_collection with format:
+        # move_collection 10658/123 10568/456 10568/789
+        move_collection $row
+    done
+}
+
+main
+
+# vim: set expandtab:ts=4:sw=4:bs=2

--- a/orcid-authority-to-item.py
+++ b/orcid-authority-to-item.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+#
+# orcid-authority-to-item.py 1.0.0
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+#
+# Map ORCID identifiers from DSpace's Solr authority core by creating new cg.creator.id
+# fields in each matching item.
+#
+# This script is written for Python 3 and requires several modules that you can
+# install with pip (I recommend setting up a Python virtual environment first):
+#
+#   $ pip install colorama psycopg2-binary requests requests-cache SolrClient
+#
+
+import argparse
+from colorama import Fore
+from datetime import timedelta
+import psycopg2
+import requests
+import requests_cache
+import signal
+from SolrClient import SolrClient
+import sys
+
+
+def main():
+    # parse the command line arguments
+    parser = argparse.ArgumentParser(description='Map ORCID identifiers from the DSpace Solr authority core to cg.creator.id fields in each item.')
+    parser.add_argument('--debug', '-d', help='Print debug messages to standard error (stderr).', action='store_true')
+    parser.add_argument("--database-name", "-db", help='Database name', required=True)
+    parser.add_argument("--database-user", "-u", help='Database username', required=True)
+    parser.add_argument("--database-pass", "-p", help='Database password', required=True)
+    parser.add_argument('--solr-url', '-s', help='URL of Solr application', default='http://localhost:8080/solr')
+    args = parser.parse_args()
+
+    # set the signal handler for SIGINT (^C) so we can exit cleanly
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # get all ORCID identifiers from Solr authority core
+    read_identifiers_from_solr(args)
+
+
+# query DSpace's authority Solr core for authority IDs with ORCID identifiers
+def read_identifiers_from_solr(args):
+    solr = SolrClient(args.solr_url)
+    # simple query from the 'authority' collection 2000 rows at a time (default is 1000)
+    # see: https://solrclient.readthedocs.io/en/latest/SolrClient.html
+    res = solr.query('authority', {'q': 'orcid_id:*'}, rows=2000)
+
+    if args.debug:
+        sys.stderr.write(Fore.GREEN + 'Total number of authorities with ORCID iDs: {0}\n\n'.format(str(res.get_num_found())) + Fore.RESET)
+
+    # initialize an empty dictionary for authorities
+    # format will be: {'d7ef744b-bbd4-4171-b449-00e37e1b776f': '0000-0002-3476-272X', ...}
+    authorities = {}
+
+    for doc in res.docs:
+        if (doc['id'] not in authorities):
+            authorities.update({doc['id']: doc['orcid_id']})
+
+    add_orcid_identifiers(args, authorities)
+
+
+# Query ORCID's public API for names associated with an identifier. Prefers to use
+# the "credit-name" field if it is present, otherwise will default to using the
+# "given-names" and "family-name" fields.
+def resolve_orcid_identifier(args, orcid):
+    # ORCID API endpoint, see: https://pub.orcid.org
+    orcid_api_base_url = 'https://pub.orcid.org/v2.1/'
+    orcid_api_endpoint = '/person'
+
+    # fetch names associated with an ORCID identifier from the ORCID API
+    if args.debug:
+        sys.stderr.write(Fore.GREEN + 'Looking up the names associated with ORCID iD: {0}\n'.format(orcid) + Fore.RESET)
+
+    # enable transparent request cache with 36 hour expiry
+    expire_after = timedelta(hours=36)
+
+    # cache HTTP 200 and 404 responses, because ORCID uses HTTP 404 when an identifier doesn't exist
+    requests_cache.install_cache('orcid-response-cache', expire_after=expire_after, allowable_codes=(200, 404))
+
+    # build request URL for current ORCID ID
+    request_url = orcid_api_base_url + orcid.strip() + orcid_api_endpoint
+
+    # ORCID's API defaults to some custom format, so tell it to give us JSON
+    request = requests.get(request_url, headers={'Accept': 'application/json'})
+
+    # prune old cache entries
+    requests_cache.core.remove_expired_responses()
+
+    # Check the request status
+    if request.status_code == requests.codes.ok:
+        # read response JSON into data
+        data = request.json()
+
+        # make sure name element is not null
+        if data['name']:
+            # prefer credit-name if present and not blank
+            if data['name']['credit-name'] and data['name']['credit-name']['value'] != '':
+                line = data['name']['credit-name']['value']
+            # otherwise use given-names + family-name
+            # make sure given-names is not null
+            elif data['name']['given-names']:
+                line = data['name']['given-names']['value']
+                # make sure family-name is not null
+                if data['name']['family-name']:
+                    line = line + ' ' + data['name']['family-name']['value']
+                else:
+                    if args.debug:
+                        sys.stderr.write(Fore.YELLOW + 'Warning: ignoring null family-name element.\n' + Fore.RESET)
+        else:
+            if args.debug:
+                sys.stderr.write(Fore.YELLOW + 'Warning: skipping identifier with null name element.\n\n' + Fore.RESET)
+    # HTTP 404 means that the API url or identifier was not found. If the
+    # API URL is correct, let's assume that the identifier was not found.
+    elif request.status_code == 404:
+        if args.debug:
+            sys.stderr.write(Fore.YELLOW + 'Warning: skipping missing identifier (API request returned HTTP 404).\n\n' + Fore.RESET)
+    else:
+        sys.stderr.write(Fore.RED + 'Error: request failed.\n' + Fore.RESET)
+        exit(1)
+
+    return line
+
+
+def add_orcid_identifiers(args, authorities):
+    # connect to database
+    try:
+        conn_string = 'dbname={0} user={1} password={2} host=localhost'.format(args.database_name, args.database_user, args.database_pass)
+        conn = psycopg2.connect(conn_string)
+
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Connected to the database.\n' + Fore.RESET)
+    except psycopg2.OperationalError:
+        sys.stderr.write(Fore.RED + 'Unable to connect to the database.\n' + Fore.RESET)
+        exit(1)
+
+    # iterate over all authorities
+    for authority_id in authorities:
+        # save orcid for current authority a little more cleanly
+        orcid = authorities[authority_id]
+
+        # get name associated with this orcid identifier
+        name = resolve_orcid_identifier(args, orcid)
+        creator = '{0}: {1}'.format(name, orcid)
+
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Processing authority ID {0} with ORCID iD: {1}\n'.format(authority_id, orcid) + Fore.RESET)
+
+        with conn:
+            # cursor will be closed after this block exits
+            # see: http://initd.org/psycopg/docs/usage.html#with-statement
+            with conn.cursor() as cursor:
+                # find all metadata records with this authority id
+                # resource_type_id 2 is item metadata, metadata_field_id 3 is author
+                sql = 'SELECT resource_id, place FROM metadatavalue WHERE resource_type_id=2 AND metadata_field_id=3 AND authority=%s'
+                # remember that tuples with one item need a comma after them!
+                cursor.execute(sql, (authority_id,))
+                records_with_authority = cursor.fetchall()
+
+                if len(records_with_authority) >= 0:
+                    if args.debug:
+                        sys.stderr.write(Fore.GREEN + 'Checking {0} items for authority ID {1}.\n'.format(len(records_with_authority), authority_id) + Fore.RESET)
+
+                    # iterate over results for current authority_id to add cg.creator.id metadata
+                    for record in records_with_authority:
+                        resource_id = record[0]
+                        # author name and orcid identifier
+                        text_value = creator
+                        place = record[1]
+                        confidence = -1
+
+                        # get the metadata_field_id for cg.creator.id field
+                        sql = "SELECT metadata_field_id FROM metadatafieldregistry WHERE metadata_schema_id=2 AND element='creator' AND qualifier='id'"
+                        cursor.execute(sql)
+                        metadata_field_id = cursor.fetchall()[0]
+
+                        # first, check if there is an existing cg.creator.id here (perhaps the script crashed before?)
+                        # resource_type_id 2 is item metadata
+                        sql = 'SELECT * from metadatavalue WHERE resource_id=%s AND metadata_field_id=%s AND text_value=%s AND place=%s AND confidence=%s AND resource_type_id=2'
+                        cursor.execute(sql, (resource_id, metadata_field_id, text_value, place, confidence))
+                        records_with_orcid = cursor.fetchall()
+
+                        if len(records_with_orcid) == 0:
+                            print('Adding ORCID identifier to item {0}: {1}'.format(resource_id, creator))
+
+                            # metadatavalue IDs come from a PostgreSQL sequence that increments when you call it
+                            cursor.execute("SELECT nextval('metadatavalue_seq')")
+                            metadata_value_id = cursor.fetchone()[0]
+
+                            sql = 'INSERT INTO metadatavalue (metadata_value_id, resource_id, metadata_field_id, text_value, place, confidence, resource_type_id) VALUES (%s, %s, %s, %s, %s, %s, %s)'
+                            cursor.execute(sql, (metadata_value_id, resource_id, metadata_field_id, text_value, place, confidence, 2))
+                        else:
+                            if args.debug:
+                                sys.stderr.write(Fore.GREEN + 'Item {0} already has an ORCID identifier for {1}.\n'.format(resource_id, creator) + Fore.RESET)
+
+    if args.debug:
+        sys.stderr.write(Fore.GREEN + 'Disconnecting from database.\n' + Fore.RESET)
+
+    # close the database connection before leaving
+    conn.close()
+
+
+def signal_handler(signal, frame):
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/resolve-orcids.py
+++ b/resolve-orcids.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+#
+# resolve-orcids.py 1.1.0
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+#
+# Queries the public ORCID API for names associated with a list of ORCID iDs
+# read from a text file or DSpace authority Solr core. Text file should have
+# one ORCID identifier per line (comments and invalid lines are skipped).
+#
+# This script is written for Python 3 and requires several modules that you can
+# install with pip (I recommend setting up a Python virtual environment first):
+#
+#   $ pip install colorama requests requests-cache SolrClient
+#
+
+import argparse
+from colorama import Fore
+from datetime import timedelta
+import re
+import requests
+import requests_cache
+import signal
+from SolrClient import SolrClient
+import sys
+
+
+# read ORCID identifiers from a text file, one per line
+def read_identifiers_from_file():
+    # initialize an empty list for ORCID iDs
+    orcids = []
+
+    for line in args.input_file:
+        # trim any leading or trailing whitespace (including newlines)
+        line = line.strip()
+
+        # regular expression for matching exactly one ORCID identifier on a line
+        pattern = re.compile('^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$')
+
+        # skip the line if it doesn't match the pattern
+        if not pattern.match(line):
+            continue
+
+        # iterate over results and add ORCID iDs that aren't already in the list
+        if line not in orcids:
+            orcids.append(line)
+
+    # close output file before we exit
+    args.input_file.close()
+
+    resolve_orcid_identifiers(orcids)
+
+
+# query DSpace's authority Solr core for ORCID identifiers
+def read_identifiers_from_solr():
+    solr = SolrClient(args.solr_url)
+    # simple query from the 'authority' collection 2000 rows at a time (default is 1000)
+    # see: https://solrclient.readthedocs.io/en/latest/SolrClient.html
+    res = solr.query('authority', {'q': 'orcid_id:*'}, rows=2000)
+
+    if args.debug:
+        sys.stderr.write(Fore.GREEN + 'Total number of Solr records with ORCID iDs: {0}\n'.format(str(res.get_num_found())) + Fore.RESET)
+
+    # initialize an empty list for ORCID iDs
+    orcids = []
+
+    # iterate over results and add ORCID iDs that aren't already in the list
+    # for example, we had 1600 ORCID iDs in Solr, but only 600 are unique
+    for doc in res.docs:
+        if doc['orcid_id'] not in orcids:
+            orcids.append(doc['orcid_id'])
+
+            # if the user requested --extract-only, write the current ORCID iD to output_file
+            if args.extract_only:
+                line = doc['orcid_id'] + '\n'
+                args.output_file.write(line)
+
+    # exit now if the user requested --extract-only
+    if args.extract_only:
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Number of unique ORCID iDs: {0}\n'.format(str(len(orcids))) + Fore.RESET)
+        # close output file before we exit
+        args.output_file.close()
+        exit()
+
+    resolve_orcid_identifiers(orcids)
+
+
+# Query ORCID's public API for names associated with identifiers. Prefers to use
+# the "credit-name" field if it is present, otherwise will default to using the
+# "given-names" and "family-name" fields.
+def resolve_orcid_identifiers(orcids):
+    if args.debug:
+        sys.stderr.write(Fore.GREEN + 'Resolving names associated with {0} unique ORCID iDs.\n\n'.format(str(len(orcids))) + Fore.RESET)
+
+    # ORCID API endpoint, see: https://pub.orcid.org
+    orcid_api_base_url = 'https://pub.orcid.org/v2.1/'
+    orcid_api_endpoint = '/person'
+
+    # iterate through our ORCID iDs and fetch their names from the ORCID API
+    for orcid in orcids:
+        if args.debug:
+            sys.stderr.write(Fore.GREEN + 'Looking up the names associated with ORCID iD: {0}\n'.format(orcid) + Fore.RESET)
+
+        # enable transparent request cache with 24 hour expiry
+        expire_after = timedelta(hours=72)
+        # cache HTTP 200 and 404 responses, because ORCID uses HTTP 404 when an identifier doesn't exist
+        requests_cache.install_cache('orcid-response-cache', expire_after=expire_after, allowable_codes=(200, 404))
+
+        # build request URL for current ORCID ID
+        request_url = orcid_api_base_url + orcid.strip() + orcid_api_endpoint
+
+        # ORCID's API defaults to some custom format, so tell it to give us JSON
+        request = requests.get(request_url, headers={'Accept': 'application/json'})
+
+        # prune old cache entries
+        requests_cache.core.remove_expired_responses()
+
+        # Check the request status
+        if request.status_code == requests.codes.ok:
+            # read response JSON into data
+            data = request.json()
+
+            # make sure name element is not null
+            if data['name']:
+                # prefer to use credit-name if present and not blank
+                if data['name']['credit-name'] and data['name']['credit-name']['value'] != '':
+                    line = data['name']['credit-name']['value']
+                # otherwise try to use given-names and or family-name
+                else:
+                    # make sure given-names is present and not deactivated
+                    if data['name']['given-names'] and data['name']['given-names']['value'] != 'Given Names Deactivated':
+                        line = data['name']['given-names']['value']
+                    else:
+                        if args.debug:
+                            sys.stderr.write(Fore.YELLOW + 'Warning: ignoring null or deactivated given-names element.\n' + Fore.RESET)
+                    # make sure family-name is present and not deactivated
+                    if data['name']['family-name'] and data['name']['family-name']['value'] != 'Family Name Deactivated':
+                        line = line + ' ' + data['name']['family-name']['value']
+                    else:
+                        if args.debug:
+                            sys.stderr.write(Fore.YELLOW + 'Warning: ignoring null or deactivated family-name element.\n' + Fore.RESET)
+                # check if line has something (a credit-name, given-names, and or family-name)
+                if line and line != '':
+                    line = '{0}: {1}'.format(line.strip(), orcid)
+                else:
+                    if args.debug:
+                        sys.stderr.write(Fore.RED + 'Error: skipping identifier with no valid name elements.\n' + Fore.RESET)
+                    continue
+
+                # output results to screen to show progress
+                if not args.quiet:
+                    print(line)
+
+                # write formatted name and ORCID identifier to output file
+                args.output_file.write(line + '\n')
+
+                # clear line for next iteration
+                line = None
+            else:
+                if args.debug:
+                    sys.stderr.write(Fore.YELLOW + 'Warning: skipping identifier with null name element.\n\n' + Fore.RESET)
+        # HTTP 404 means that the API url or identifier was not found. If the
+        # API URL is correct, let's assume that the identifier was not found.
+        elif request.status_code == 404:
+            if args.debug:
+                sys.stderr.write(Fore.YELLOW + 'Warning: skipping missing identifier (API request returned HTTP 404).\n\n' + Fore.RESET)
+                continue
+        # HTTP 409 means that the identifier is locked for some reason
+        # See: https://members.orcid.org/api/resources/error-codes
+        elif request.status_code == 409:
+            if args.debug:
+                sys.stderr.write(Fore.YELLOW + 'Warning: skipping locked identifier (API request returned HTTP 409).\n\n' + Fore.RESET)
+                continue
+        else:
+            sys.stderr.write(Fore.RED + 'Error: request failed.\n' + Fore.RESET)
+            # close output file before we exit
+            args.output_file.close()
+            exit(1)
+
+    # close output file before we exit
+    args.output_file.close()
+
+
+def signal_handler(signal, frame):
+    # close output file before we exit
+    args.output_file.close()
+
+    sys.exit(1)
+
+
+parser = argparse.ArgumentParser(description='Query the public ORCID API for names associated with a list of ORCID identifiers, either from a text file or a DSpace authority Solr core. Optional "extract only" mode will simply fetch the ORCID identifiers from Solr and write them to the output file without resolving their names from ORCID\'s API.')
+parser.add_argument('--debug', '-d', help='Print debug messages to standard error (stderr).', action='store_true')
+parser.add_argument('--extract-only', '-e', help='If fetching ORCID identifiers from Solr, write them to the output file without resolving their names from the ORCID API.', action='store_true')
+parser.add_argument('--output-file', '-o', help='Name of output file to write to.', required=True, type=argparse.FileType('w', encoding='UTF-8'))
+parser.add_argument('--quiet', '-q', help='Do not print results to screen as we find them (results will still go to output file).', action='store_true')
+# group of mutually exclusive options
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--input-file', '-i', help='File name containing ORCID identifiers to resolve.', type=argparse.FileType('r'))
+group.add_argument('--solr-url', '-s', help='URL of Solr application (for example: http://localhost:8080/solr).')
+args = parser.parse_args()
+
+# set the signal handler for SIGINT (^C) so we can exit cleanly
+signal.signal(signal.SIGINT, signal_handler)
+
+# if the user specified an input file, get the ORCID identifiers from there
+if args.input_file:
+    read_identifiers_from_file()
+# otherwise, get the ORCID identifiers from Solr
+elif args.solr_url:
+    read_identifiers_from_solr()
+
+exit()

--- a/rest-find-collections.py
+++ b/rest-find-collections.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+#
+# rest-find-collections.py 1.1.1
+#
+# Copyright 2018 Alan Orth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ---
+#
+# A quick and dirty example for parsing the DSpace REST API to find and print
+# the names of all collections contained in a community hierarchy. It expects
+# exactly one command line argument: the handle of a community. For example:
+#
+#   $ ./rest-find-collections.py 10568/1
+#
+# You can optionally specify the URL of a DSpace REST application (default is to
+# use http://localhost:8080/rest).
+#
+# This script is written for Python 3 and requires several modules that you can
+# install with pip (I recommend setting up a Python virtual environment first):
+#
+#   $ pip install requests colorama
+#
+# See: https://requests.readthedocs.org/en/master
+
+import argparse
+from colorama import Fore
+import requests
+import signal
+import sys
+
+
+def signal_handler(signal, frame):
+    sys.exit(1)
+
+
+
+def parse_community(community_id):
+    request_url = rest_base_url + rest_communities_endpoint + str(community_id) + '?expand=collections,subCommunities'
+    try:
+        request = requests.get(request_url, headers={'user-agent': rest_user_agent})
+    except requests.ConnectionError:
+        sys.stderr.write(Fore.RED + 'Could not connect to {0}.\n'.format(args.rest_url) + Fore.RESET)
+        exit(1)
+
+    if request.status_code == requests.codes.ok:
+        subcommunities = request.json()['subcommunities']
+        collections = request.json()['collections']
+
+        for subcommunity in subcommunities:
+            subcommunity_id = subcommunity['id']
+
+            if args.debug:
+                sys.stderr.write(Fore.YELLOW + 'Found subcommunity (id: {subcommunity_id}, handle: {subcommunity_handle}): {subcommunity_name} ==> I must go deeper!\n'.format(subcommunity_id=str(subcommunity_id), subcommunity_handle=subcommunity['handle'], subcommunity_name=subcommunity['name']) + Fore.RESET)
+
+            parse_community(subcommunity_id)
+
+        for collection in collections:
+            if args.debug:
+                sys.stderr.write(Fore.YELLOW + 'Found collection (id: {collection_id}, handle: {collection_handle}): {collection_name}\n'.format(collection_id=str(collection['id']), collection_handle=collection['handle'], collection_name=collection['name']) + Fore.RESET)
+
+            all_collections.append(collection['name'])
+    else:
+        sys.stderr.write(Fore.RED + 'Status not ok! Request URL was: {request_url}\n'.format(request_url=request.url) + Fore.RESET)
+        exit(1)
+
+
+parser = argparse.ArgumentParser(description='Find all collections under a given DSpace community.')
+parser.add_argument('community', help='Community to process, for example: 10568/1')
+parser.add_argument('--debug', '-d', help='Print debug messages.', action='store_true')
+parser.add_argument('--rest-url', '-u', help='URL of DSpace REST application.', default='http://localhost:8080/rest')
+args = parser.parse_args()
+
+handle = args.community
+
+# REST base URL and endpoints (with leading and trailing slashes)
+rest_base_url = args.rest_url
+rest_handle_endpoint = '/handle/'
+rest_communities_endpoint = '/communities/'
+rest_collections_endpoint = '/collections/'
+rest_user_agent = 'Alan Test Python Requests Bot'
+
+# initialize empty list of all collections
+all_collections = []
+
+# set the signal handler for SIGINT (^C)
+signal.signal(signal.SIGINT, signal_handler)
+
+# fetch the metadata for the given handle
+request_url = rest_base_url + rest_handle_endpoint + str(handle)
+
+try:
+    request = requests.get(request_url, headers={'user-agent': rest_user_agent})
+except requests.ConnectionError:
+    sys.stderr.write(Fore.RED + 'Could not connect to REST API: {0}.\n'.format(args.rest_url) + Fore.RESET)
+    exit(1)
+
+# Check the request status
+if request.status_code == requests.codes.ok:
+    handle_type = request.json()['type']
+
+    # Make sure the given handle is a community
+    if handle_type == 'community':
+        community_id = request.json()['id']
+        parse_community(community_id)
+
+        for collection in all_collections:
+            print(Fore.GREEN + 'Name of collection: {collection}'.format(collection=collection) + Fore.RESET)
+    else:
+        sys.stderr.write(Fore.RED + '{handle} is type "{handle_type}", not community.\n'.format(handle=handle, handle_type=handle_type) + Fore.RESET)
+        exit(1)
+else:
+    sys.stderr.write(Fore.RED + 'Request failed. Are you sure {handle} is a valid handle?\n'.format(handle=handle) + Fore.RESET)
+    exit(1)


### PR DESCRIPTION
This formally adds my Python- and shell-based metadata workflow scripts to the source directory, as well as pipenv environment. The scripts were previously just collected on the [wiki of our DSpace repository](https://github.com/ilri/DSpace/wiki/Scripts).