### PR TITLE
input-forms.xml: Update country names

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -5233,8 +5233,8 @@
         <stored-value>LUXEMBOURG</stored-value>
       </pair>
       <pair>
-        <displayed-value>MACEDONIA</displayed-value>
-        <stored-value>MACEDONIA</stored-value>
+        <displayed-value>NORTH MACEDONIA</displayed-value>
+        <stored-value>NORTH MACEDONIA</stored-value>
       </pair>
       <pair>
         <displayed-value>MADAGASCAR</displayed-value>
@@ -5461,8 +5461,8 @@
         <stored-value>SURINAME</stored-value>
       </pair>
       <pair>
-        <displayed-value>SWAZILAND</displayed-value>
-        <stored-value>SWAZILAND</stored-value>
+        <displayed-value>ESWATINI</displayed-value>
+        <stored-value>ESWATINI</stored-value>
       </pair>
       <pair>
         <displayed-value>SWEDEN</displayed-value>


### PR DESCRIPTION
Swaziland renamed itself to Eswatini in 2018-04 and Macedonia changed its name to North Macedonia in 2019-02. I'm still not sure whether we will change all existing metadata in the database.