### PR TITLE
Update social icons in XMLUI

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -734,7 +734,7 @@ such as authors, subject, citation, description, etc
                 Share
             </h5>
             <a>
-                <xsl:attribute name="href"><xsl:text>https://twitter.com/home?status=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
+                <xsl:attribute name="href"><xsl:text>https://twitter.com/intent/tweet?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/><xsl:text>&amp;text=</xsl:text><xsl:value-of select="dim:field[@element='title']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Tweet this</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
                 <span class="fa fa-twitter-square fa-2x"></span>
@@ -758,7 +758,7 @@ such as authors, subject, citation, description, etc
                 <span class="ai ai-mendeley-square ai-2x" aria-hidden="true"></span>
             </a>
             <a>
-                <xsl:attribute name="href"><xsl:text>mailto:?&amp;body=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/><xsl:text>&amp;media=&amp;description=</xsl:text></xsl:attribute>
+                <xsl:attribute name="href"><xsl:text>mailto:?&amp;body=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/><xsl:text>&amp;media=&amp;subject=</xsl:text><xsl:value-of select="dim:field[@element='title']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share via e-mail</xsl:text></xsl:attribute>
                 <span class="fa fa-envelope fa-2x" aria-hidden="true"></span>
             </a>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/0_CGIAR/xsl/aspect/artifactbrowser/item-view-DIM-helper.xsl
@@ -746,22 +746,10 @@ such as authors, subject, citation, description, etc
                 <span class="fa fa-facebook-square fa-2x" aria-hidden="true"></span>
             </a>
             <a>
-                <xsl:attribute name="href"><xsl:text>https://plus.google.com/share?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
-                <xsl:attribute name="title"><xsl:text>Share on Google+</xsl:text></xsl:attribute>
-                <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
-                <span class="fa fa-google-plus-square fa-2x" aria-hidden="true"></span>
-            </a>
-            <a>
                 <xsl:attribute name="href"><xsl:text>https://www.linkedin.com/shareArticle?mini=true&amp;url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
                 <xsl:attribute name="title"><xsl:text>Share on LinkedIn</xsl:text></xsl:attribute>
                 <xsl:attribute name="target"><xsl:text>blank</xsl:text></xsl:attribute>
                 <span class="fa fa-linkedin-square fa-2x" aria-hidden="true"></span>
-            </a>
-            <a>
-                <xsl:attribute name="href"><xsl:text>https://delicious.com/save?v=5&amp;provider=CGSpace&amp;noui&amp;jump=close&amp;url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>
-                <xsl:attribute name="title"><xsl:text>Save this on Delicious</xsl:text></xsl:attribute>
-                <xsl:attribute name="target"><xsl:text>_blank</xsl:text></xsl:attribute>
-                <span class="fa fa-delicious fa-2x" aria-hidden="true"></span>
             </a>
             <a>
                 <xsl:attribute name="href"><xsl:text>https://www.mendeley.com/import/?url=</xsl:text><xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']"/></xsl:attribute>


### PR DESCRIPTION
Remove Google+ and Delicious (deprecated), and update share parameters for Twitter and email to include item title.

Closes #419. 