### PR TITLE
dspace-rest: Log item id on error

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -1091,11 +1091,11 @@ public class ItemsResource extends Resource
                 if (context.getCurrentUser() != null)
                 {
                     log.error("User(" + context.getCurrentUser().getEmail() + ") has not permission to "
-                            + getActionString(action) + " item!");
+                            + getActionString(action) + " item(id=" + id + ")!");
                 }
                 else
                 {
-                    log.error("User(anonymous) has not permission to " + getActionString(action) + " item!");
+                    log.error("User(anonymous) has not permission to " + getActionString(action) + " item(id=" + id + ")!");
                 }
                 throw new WebApplicationException(Response.Status.UNAUTHORIZED);
             }


### PR DESCRIPTION
Errors encountered when searching for items using the REST API's `/items/find-by-metadata-value` endpoint are printed without the ID that caused the error, making it impossible to troubleshoot.