### PR TITLE
Increase filterCache on Solr statistics core

### DIFF
--- a/dspace/solr/statistics/conf/solrconfig.xml
+++ b/dspace/solr/statistics/conf/solrconfig.xml
@@ -508,8 +508,8 @@
                and old cache.  
       -->
     <filterCache class="solr.FastLRUCache"
-                 size="512"
-                 initialSize="512"
+                 size="16384"
+                 initialSize="16384"
                  autowarmCount="0"/>
 
     <!-- Query Result Cache


### PR DESCRIPTION
In my tests with the dspace-statistics-api this *drastically* helps the indexing speed and actually reduces memory usage and instances of garbage collection. I tested the default value of 512 as well as 1024, 2048, 4096, and finally settled on 16384.

See: https://alanorth.github.io/cgspace-notes/2019-04/#2019-04-17