### PR TITLE
Enhance XHTML meta tags

### DIFF
--- a/dspace/config/crosswalks/google-metadata.properties
+++ b/dspace/config/crosswalks/google-metadata.properties
@@ -47,7 +47,7 @@ google.citation_fulltext_html_url =
 google.citation_pdf_url = $simple-pdf
 google.citation_keywords = dc.subject, dc.type
 
-google.citation_journal_title =
+google.citation_journal_title = dc.source
 google.citation_volume =
 google.citation_issue =
 google.citation_firstpage =

--- a/dspace/config/crosswalks/xhtml-head-item.properties
+++ b/dspace/config/crosswalks/xhtml-head-item.properties
@@ -7,6 +7,7 @@
 
 schema.DC = http://purl.org/dc/elements/1.1/
 schema.DCTERMS = http://purl.org/dc/terms/
+schema.CG = https://agriculturalsemantics.github.io/cg-core/cgcore.html
 
 
 ####### Metadata field mappings #######
@@ -75,3 +76,4 @@ dc.subject.mesh                = DC.subject,DCTERMS.MESH
 dc.title                       = DC.title
 dc.title.alternative           = DCTERMS.alternative
 dc.type                        = DC.type
+cg.identifier.status           = DCTERMS.accessRights


### PR DESCRIPTION
After looking at the list of tags read by Altmetric I decided that we can actually add a few more of these very easily. Adding access rights and journal title is very easy.

See: https://help.altmetric.com/support/solutions/articles/6000141419-what-metadata-is-required-to-track-our-content-