### PR TITLE
input-forms.xml: Add OGL-UK-3.0

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -1748,6 +1748,10 @@
         <stored-value>CC-BY-NC-ND</stored-value>
       </pair>
       <pair>
+        <displayed-value>Open Government Licence v3.0 (OGL-UK-3.0)</displayed-value>
+        <stored-value>OGL-UK-3.0</stored-value>
+      </pair>
+      <pair>
         <displayed-value>Copyrighted; all rights reserved</displayed-value>
         <stored-value>Copyrighted; all rights reserved</stored-value>
       </pair>


### PR DESCRIPTION
Some items use the UK's "Open Government Licence v3.0" so I will add its SPDX identifier to our controlled vocabulary. Closes #439

See: https://spdx.org/licenses/OGL-UK-3.0.html