### PR TITLE
Increase maxBooleanClauses for all Solr cores

### DIFF
--- a/dspace/solr/authority/conf/solrconfig.xml
+++ b/dspace/solr/authority/conf/solrconfig.xml
@@ -389,7 +389,7 @@
          be based on the last SolrCore to be initialized.
 
       -->
-    <maxBooleanClauses>1024</maxBooleanClauses>
+    <maxBooleanClauses>2048</maxBooleanClauses>
 
 
     <!-- Solr Internal Query Caches

--- a/dspace/solr/datatables/conf/solrconfig.xml
+++ b/dspace/solr/datatables/conf/solrconfig.xml
@@ -473,7 +473,7 @@
          be based on the last SolrCore to be initialized.
          
       -->
-    <maxBooleanClauses>1024</maxBooleanClauses>
+    <maxBooleanClauses>2048</maxBooleanClauses>
 
 
     <!-- Solr Internal Query Caches

--- a/dspace/solr/oai/conf/solrconfig.xml
+++ b/dspace/solr/oai/conf/solrconfig.xml
@@ -473,7 +473,7 @@
          be based on the last SolrCore to be initialized.
          
       -->
-    <maxBooleanClauses>1024</maxBooleanClauses>
+    <maxBooleanClauses>2048</maxBooleanClauses>
 
 
     <!-- Solr Internal Query Caches

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -473,7 +473,7 @@
          be based on the last SolrCore to be initialized.
          
       -->
-    <maxBooleanClauses>1024</maxBooleanClauses>
+    <maxBooleanClauses>2048</maxBooleanClauses>
 
 
     <!-- Solr Internal Query Caches

--- a/dspace/solr/statistics/conf/solrconfig.xml
+++ b/dspace/solr/statistics/conf/solrconfig.xml
@@ -473,7 +473,7 @@
          be based on the last SolrCore to be initialized.
          
       -->
-    <maxBooleanClauses>1024</maxBooleanClauses>
+    <maxBooleanClauses>2048</maxBooleanClauses>
 
 
     <!-- Solr Internal Query Caches


### PR DESCRIPTION
This solves an issue when a user belongs to too many groups, which causes the Solr query to have too many "OR" clauses when searching for communities and collections they have access to. We only need the increased value in the search core, but one comment notes that this setting modifies an internal Lucene variable globally, so it can get reset depending on the order cores are loaded in.

The error in the DSpace log is: too many boolean clauses.